### PR TITLE
Add POST body logging to audit trail

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Request Body Logging** — POST/PUT/PATCH request bodies now logged in audit trail
+  - Bodies automatically truncated at 10KB to prevent log bloat from file uploads
+  - New `requestBody` field in audit events (optional)
+  - Config option `server.logBodies` to disable (default: `true`)
+  - No automatic redaction — full visibility into what agents sent
+
 ## [0.2.2] - 2026-02-04
 
 ### Improved

--- a/src/cli/commands/serve-mcp.ts
+++ b/src/cli/commands/serve-mcp.ts
@@ -43,8 +43,11 @@ export async function serveMCPCommand(): Promise<void> {
       process.exit(1);
     }
 
+    const config = loadYAMLConfig();
     const sessionManager = new SessionManager();
-    const auditLogger = new AuditLogger(getAuditDir());
+    const auditLogger = new AuditLogger(getAuditDir(), {
+      logBodies: config.server.logBodies
+    });
 
     // Load initial config
     const { capabilities, services } = loadConfigForMCP();

--- a/src/cli/config-yaml.ts
+++ b/src/cli/config-yaml.ts
@@ -45,6 +45,7 @@ export interface LLMConfig {
 export interface ServerConfig {
   port: number;
   host: string;
+  logBodies?: boolean;  // Log request bodies in audit trail (default: true)
 }
 
 export interface JaneeYAMLConfig {

--- a/src/core/audit.test.ts
+++ b/src/core/audit.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for audit logger
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { AuditLogger, APIRequest, APIResponse } from './audit';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('AuditLogger', () => {
+  let tempDir: string;
+  let logger: AuditLogger;
+
+  beforeEach(() => {
+    // Create temp directory for test logs
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'janee-test-'));
+    logger = new AuditLogger(tempDir);
+  });
+
+  afterEach(() => {
+    // Clean up temp directory
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('Request Body Logging', () => {
+    it('should log POST request body when enabled (default)', () => {
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'POST',
+        path: '/v1/test',
+        headers: {},
+        body: JSON.stringify({ test: 'data' })
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      logger.log(request, response);
+
+      // Read log file
+      const logFiles = fs.readdirSync(tempDir);
+      expect(logFiles.length).toBe(1);
+
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBe(JSON.stringify({ test: 'data' }));
+      expect(logEntry.method).toBe('POST');
+    });
+
+    it('should log PUT request body', () => {
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'PUT',
+        path: '/v1/test/123',
+        headers: {},
+        body: JSON.stringify({ updated: true })
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      logger.log(request, response);
+
+      const logFiles = fs.readdirSync(tempDir);
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBe(JSON.stringify({ updated: true }));
+    });
+
+    it('should log PATCH request body', () => {
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'PATCH',
+        path: '/v1/test/123',
+        headers: {},
+        body: JSON.stringify({ patched: true })
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      logger.log(request, response);
+
+      const logFiles = fs.readdirSync(tempDir);
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBe(JSON.stringify({ patched: true }));
+    });
+
+    it('should not log GET request body', () => {
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'GET',
+        path: '/v1/test',
+        headers: {},
+        body: 'should-not-be-logged'
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      logger.log(request, response);
+
+      const logFiles = fs.readdirSync(tempDir);
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBeUndefined();
+    });
+
+    it('should not log DELETE request body', () => {
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'DELETE',
+        path: '/v1/test/123',
+        headers: {},
+        body: 'should-not-be-logged'
+      };
+
+      const response: APIResponse = {
+        statusCode: 204,
+        headers: {},
+        body: ''
+      };
+
+      logger.log(request, response);
+
+      const logFiles = fs.readdirSync(tempDir);
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBeUndefined();
+    });
+
+    it('should not log body when logBodies is false', () => {
+      const loggerNoBody = new AuditLogger(tempDir, { logBodies: false });
+
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'POST',
+        path: '/v1/test',
+        headers: {},
+        body: JSON.stringify({ test: 'data' })
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      loggerNoBody.log(request, response);
+
+      const logFiles = fs.readdirSync(tempDir);
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBeUndefined();
+    });
+
+    it('should truncate large request bodies at 10KB', () => {
+      // Create a body larger than 10KB
+      const largeBody = 'x'.repeat(15 * 1024); // 15KB
+
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'POST',
+        path: '/v1/test',
+        headers: {},
+        body: largeBody
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      logger.log(request, response);
+
+      const logFiles = fs.readdirSync(tempDir);
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBeDefined();
+      expect(logEntry.requestBody?.length).toBeLessThan(largeBody.length);
+      expect(logEntry.requestBody).toContain('... [truncated, original length: 15360]');
+      expect(logEntry.requestBody?.substring(0, 10240)).toBe(largeBody.substring(0, 10240));
+    });
+
+    it('should not truncate bodies under 10KB', () => {
+      const smallBody = 'x'.repeat(5 * 1024); // 5KB
+
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'POST',
+        path: '/v1/test',
+        headers: {},
+        body: smallBody
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      logger.log(request, response);
+
+      const logFiles = fs.readdirSync(tempDir);
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBe(smallBody);
+      expect(logEntry.requestBody).not.toContain('[truncated');
+    });
+
+    it('should handle missing request body', () => {
+      const request: APIRequest = {
+        service: 'test-service',
+        method: 'POST',
+        path: '/v1/test',
+        headers: {}
+        // No body
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      logger.log(request, response);
+
+      const logFiles = fs.readdirSync(tempDir);
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.requestBody).toBeUndefined();
+    });
+  });
+
+  describe('Basic Logging', () => {
+    it('should log basic request metadata', () => {
+      const request: APIRequest = {
+        service: 'stripe',
+        method: 'GET',
+        path: '/v1/balance',
+        headers: {}
+      };
+
+      const response: APIResponse = {
+        statusCode: 200,
+        headers: {},
+        body: '{}'
+      };
+
+      logger.log(request, response, 123);
+
+      const logFiles = fs.readdirSync(tempDir);
+      expect(logFiles.length).toBe(1);
+
+      const logContent = fs.readFileSync(path.join(tempDir, logFiles[0]), 'utf8');
+      const logEntry = JSON.parse(logContent.trim());
+
+      expect(logEntry.service).toBe('stripe');
+      expect(logEntry.method).toBe('GET');
+      expect(logEntry.path).toBe('/v1/balance');
+      expect(logEntry.statusCode).toBe(200);
+      expect(logEntry.duration).toBe(123);
+      expect(logEntry.id).toBeDefined();
+      expect(logEntry.timestamp).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds request body logging to the audit trail for POST/PUT/PATCH requests, addressing the gap in audit coverage.

## Changes

- **Request body logging**: Bodies for POST/PUT/PATCH requests now logged in audit events
- **Truncation**: Bodies truncated at 10KB to prevent log bloat from file uploads  
- **Config option**: New `server.logBodies` setting (default: `true`) to disable body logging
- **AuditEvent interface**: Added optional `requestBody` field
- **No redaction**: Bodies logged as-is to avoid false confidence

## Configuration

In `~/.janee/config.yaml`:

```yaml
server:
  port: 9119
  host: localhost
  logBodies: true  # Set false to disable request body logging
```

## Testing

- 10 new test cases covering:
  - POST/PUT/PATCH body logging
  - GET/DELETE body exclusion
  - Truncation at 10KB
  - Config toggle behavior
  - Missing body handling

All tests pass ✅

## Checklist

- [x] Tests added and passing
- [x] CHANGELOG.md updated
- [x] Build succeeds
- [x] Security implications considered (no auto-redaction by design)

Closes #[issue-number-if-any]