### PR TITLE
feat: non-interactive janee add for agent-driven setup

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,6 +35,11 @@ program
   .option('-u, --url <url>', 'Base URL of the service')
   .option('-k, --key <key>', 'API key for the service')
   .option('--auth-type <type>', 'Authentication type (bearer/basic/hmac/hmac-bybit/hmac-okx/headers/service-account)')
+  .option('--api-secret <secret>', 'API secret (for hmac auth types)')
+  .option('--passphrase <passphrase>', 'Passphrase (for hmac-okx)')
+  .option('--key-from-env <var>', 'Read API key from environment variable')
+  .option('--secret-from-env <var>', 'Read API secret from environment variable')
+  .option('--passphrase-from-env <var>', 'Read passphrase from environment variable')
   .option('--credentials-file <path>', 'Path to service account JSON file (for service-account auth type)')
   .option('--scope <scope...>', 'OAuth scope(s) for service-account auth type')
   .action(addCommand);


### PR DESCRIPTION
## Summary

- Adds `--api-secret`, `--passphrase`, `--key-from-env`, `--secret-from-env`, and `--passphrase-from-env` flags to `janee add`
- When all required info is provided via flags, readline is never opened — no hanging, no prompts
- Auto-creates a capability with sensible defaults (1h TTL, auto-approve) in non-interactive mode
- Interactive mode is completely unchanged

## Motivation

AI agents (Claude Code, Cursor, etc.) can't respond to interactive readline prompts. This makes `janee add` unusable from agents. These flags enable fully non-interactive setup:

```bash
# Bearer service — key stays out of LLM context window
janee add stripe --auth-type bearer --key-from-env STRIPE_KEY

# HMAC service
janee add bybit --auth-type hmac-bybit --key-from-env BYBIT_KEY --secret-from-env BYBIT_SECRET

# OKX (three credentials)
janee add okx --auth-type hmac-okx --key-from-env OKX_KEY --secret-from-env OKX_SECRET --passphrase-from-env OKX_PASS
```

The `--*-from-env` flags reference environment variables by **name** so secret values never appear in the agent's conversation/context window.

## Test plan

- [x] `npm run build` — compiles clean
- [x] `npm test` — 89/89 tests pass
- [ ] Manual: `janee add myapi -u https://httpbin.org --auth-type bearer --key-from-env TEST_KEY` with `TEST_KEY` set
- [ ] Manual: `janee add` still works interactively
- [ ] Manual: conflicting flags (`--key` + `--key-from-env`) errors clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)