### PR TITLE
docs: Non-interactive janee add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,25 @@ janee sessions         # List active sessions
 janee revoke <id>      # Kill a session
 ```
 
+### Non-interactive Setup (for AI agents)
+
+AI agents can't respond to interactive prompts. Use `--*-from-env` flags to read credentials from environment variables — this keeps secrets out of the agent's context window:
+
+```bash
+# Bearer auth (Stripe, OpenAI, etc.)
+janee add stripe -u https://api.stripe.com --auth-type bearer --key-from-env STRIPE_KEY
+
+# HMAC auth (Bybit)
+janee add bybit --auth-type hmac-bybit --key-from-env BYBIT_KEY --secret-from-env BYBIT_SECRET
+
+# HMAC auth with passphrase (OKX)
+janee add okx --auth-type hmac-okx --key-from-env OKX_KEY --secret-from-env OKX_SECRET --passphrase-from-env OKX_PASS
+```
+
+When all required credentials are provided via flags, Janee:
+- Never opens readline (no hanging on stdin)
+- Auto-creates a capability with sensible defaults (1h TTL, auto-approve)
+
 You can also edit `~/.janee/config.yaml` directly if you prefer.
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,11 +30,29 @@ janee init
 
 ## Add a Service
 
+**Interactive (for humans):**
 ```bash
 janee add
 ```
 
 Follow the prompts to add your API credentials. Keys are encrypted automatically.
+
+**Non-interactive (for agents):**
+
+Use `--*-from-env` flags to read credentials from environment variables. This keeps secrets out of your context window:
+
+```bash
+# Bearer auth (most APIs)
+janee add stripe -u https://api.stripe.com --auth-type bearer --key-from-env STRIPE_KEY
+
+# HMAC auth (Bybit, MEXC)
+janee add bybit --auth-type hmac-bybit --key-from-env BYBIT_KEY --secret-from-env BYBIT_SECRET
+
+# HMAC with passphrase (OKX)
+janee add okx --auth-type hmac-okx --key-from-env OKX_KEY --secret-from-env OKX_SECRET --passphrase-from-env OKX_PASS
+```
+
+When all credentials are provided via flags, Janee auto-creates a capability (1h TTL, auto-approve) and never prompts.
 
 ## Use in Your Agent
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Non-interactive `janee add`** — Agent-friendly setup without readline prompts (#9)
+  - New flags: `--api-secret`, `--passphrase` for direct credential input
+  - New flags: `--key-from-env`, `--secret-from-env`, `--passphrase-from-env` to read credentials from environment variables (keeps secrets out of command args and agent context)
+  - Auto-creates capability with sensible defaults (1h TTL, auto-approve) when fully non-interactive
+  - Lazy readline initialization — stdin only opened when prompts are actually needed
+  - Interactive mode unchanged
+
 ## [0.3.0] - 2026-02-04
 
 ### Added


### PR DESCRIPTION
Companion documentation for PR #9 (non-interactive add for agent-driven setup).

**Changes:**
- **CHANGELOG.md**: Document new flags and auto-capability behavior
- **README.md**: Add 'Non-interactive Setup' section with examples  
- **SKILL.md**: Add agent-friendly setup examples

**Options:**
1. Merge this first, then merge #9
2. Ask contributor to cherry-pick this commit into their branch
3. Merge #9 first, then merge this

Any order works — they're complementary.