### PR TITLE
Fix #32: Read CLI version from package.json

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CLI Version Command** — `janee --version` now reports actual installed version instead of hardcoded 0.2.1 (#32)
+  - Reads version dynamically from package.json at runtime
+  - Previously version string was hardcoded and not updated with releases
+
 ## [0.4.3] - 2026-02-10
 
 ### Added

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,13 +15,20 @@ import { logsCommand } from './commands/logs';
 import { sessionsCommand } from './commands/sessions';
 import { revokeCommand } from './commands/revoke';
 import { searchCommand } from './commands/search';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Read version from package.json
+const packageJsonPath = join(__dirname, '../../package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const version = packageJson.version || '0.0.0';
 
 const program = new Command();
 
 program
   .name('janee')
   .description('Secrets management for AI agents')
-  .version('0.2.1');
+  .version(version);
 
 // Commands
 program


### PR DESCRIPTION
## Problem

`janee --version` was hardcoded to return '0.2.1' in src/cli/index.ts, regardless of which version was installed from npm.

Reported in #32 — users installing v0.4.3 from npm were seeing v0.2.1 when running `janee --version`.

## Solution

- Read version dynamically from package.json at runtime
- Use fs.readFileSync to load package.json and parse version field
- Fallback to '0.0.0' if version field is missing (defensive)

## Testing

✅ Built successfully with `npm run build`
✅ Verified `node dist/cli/index.js --version` returns `0.4.3`
✅ Verified `node dist/cli/index.js -V` returns `0.4.3`
✅ All tests pass (`npm test` — 102 tests)

## Checklist

- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Closes #32