### PR TITLE
Add --json flag to list, sessions, and logs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,13 @@ janee add              # Add a service (interactive)
 janee add stripe -u https://api.stripe.com -k sk_xxx  # Add with args
 janee remove <service> # Remove a service
 janee list             # List configured services
+janee list --json      # Output as JSON (for integrations)
 janee serve            # Start MCP server
 janee logs             # View audit log
 janee logs -f          # Tail audit log
+janee logs --json      # Output as JSON
 janee sessions         # List active sessions
+janee sessions --json  # Output as JSON
 janee revoke <id>      # Kill a session
 ```
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **JSON Output for CLI Commands** — Add `--json` flag to `janee list`, `janee sessions`, and `janee logs` for programmatic integrations (#34)
+  - `janee list --json` outputs structured service/capability data (no secrets)
+  - `janee sessions --json` outputs active session details with TTL in seconds
+  - `janee logs --json` outputs audit log entries (not supported with `--follow`)
+  - Enables integration with RPC brokers and backend systems (e.g., The Office plugin system)
+
 ### Fixed
 
 - **CLI Version Command** — `janee --version` now reports actual installed version instead of hardcoded 0.2.1 (#32)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -64,6 +64,7 @@ program
 program
   .command('list')
   .description('List configured services')
+  .option('--json', 'Output as JSON')
   .action(listCommand);
 
 program
@@ -72,11 +73,13 @@ program
   .option('-f, --follow', 'Follow logs in real-time')
   .option('-n, --lines <count>', 'Number of recent logs to show', '20')
   .option('-s, --service <name>', 'Filter by service')
+  .option('--json', 'Output as JSON (not supported with --follow)')
   .action(logsCommand);
 
 program
   .command('sessions')
   .description('List active sessions')
+  .option('--json', 'Output as JSON')
   .action(sessionsCommand);
 
 program


### PR DESCRIPTION
## Problem

The Office backend plugin system needs to integrate with Janee by spawning CLI commands and parsing structured output. Currently, commands only output human-readable text.

Reading `~/.janee/config.yaml` directly isn't an option — it contains encrypted secrets and would bypass Janee's security model.

## Solution

Add `--json` flag to three commands for programmatic integrations:

### `janee list --json`
Outputs structured service and capability data (no secrets):
```json
{
  "services": [
    { "name": "stripe", "baseUrl": "https://api.stripe.com", "authType": "bearer" }
  ],
  "capabilities": []
}
```

### `janee sessions --json`
Outputs active sessions with TTL in seconds:
```json
{
  "sessions": [
    {
      "id": "jnee_sess_...",
      "capability": "stripe",
      "service": "stripe",
      "createdAt": "2026-02-10T11:30:24.051Z",
      "expiresAt": "2026-02-10T12:30:24.051Z",
      "ttlSeconds": 2789
    }
  ]
}
```

### `janee logs --json`
Outputs audit log entries (not supported with `--follow`):
```json
{
  "logs": [
    {
      "id": "mlgirpydj1owuuiabem",
      "timestamp": "2026-02-10T11:30:24.421Z",
      "method": "GET",
      "service": "bybit",
      "path": "/v5/account/wallet-balance",
      "statusCode": 200
    }
  ]
}
```

## Security

- **No secrets in JSON output** — Only service names, URLs, and auth types (no keys, tokens, or headers)
- Error cases return JSON with `error` field instead of human-readable text

## Testing

✅ All existing tests pass (102 tests)  
✅ Manual verification:
- `janee list --json` returns structured data
- `janee sessions --json` returns active sessions
- `janee logs --json` returns audit entries
- Error cases return `{ "error": "..." }`

## Bonus

Implements all three commands requested in the issue (list, sessions, logs) for consistency.

## Checklist

- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] README.md updated with --json examples
- [x] Closes #34