### PR TITLE
Add --yes flag to remove and --json flag to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,19 +299,22 @@ capabilities:
 ## CLI Reference
 
 ```bash
-janee init             # Set up ~/.janee/ with example config
-janee add              # Add a service (interactive)
+janee init                    # Set up ~/.janee/ with example config
+janee add                     # Add a service (interactive)
 janee add stripe -u https://api.stripe.com -k sk_xxx  # Add with args
-janee remove <service> # Remove a service
-janee list             # List configured services
-janee list --json      # Output as JSON (for integrations)
-janee serve            # Start MCP server
-janee logs             # View audit log
-janee logs -f          # Tail audit log
-janee logs --json      # Output as JSON
-janee sessions         # List active sessions
-janee sessions --json  # Output as JSON
-janee revoke <id>      # Kill a session
+janee remove <service>        # Remove a service
+janee remove <service> --yes  # Remove without confirmation
+janee list                    # List configured services
+janee list --json             # Output as JSON (for integrations)
+janee search [query]          # Search service directory
+janee search stripe --json    # Search with JSON output
+janee serve                   # Start MCP server
+janee logs                    # View audit log
+janee logs -f                 # Tail audit log
+janee logs --json             # Output as JSON
+janee sessions                # List active sessions
+janee sessions --json         # Output as JSON
+janee revoke <id>             # Kill a session
 ```
 
 ### Non-interactive Setup (for AI agents)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **JSON Output for Search Command** — Add `--json` flag to `janee search` for programmatic directory access (#37)
+  - `janee search <query> --json` outputs matching services as JSON array
+  - `janee search --json` outputs entire service directory
+  - Includes service metadata: name, description, baseUrl, authType, authFields, category, tags, docs
+  - Enables building service directory UIs in external applications
+- **Non-interactive Remove Command** — Add `--yes` flag to `janee remove` to skip confirmation prompt (#36)
+  - `janee remove <service> --yes` removes service without interactive confirmation
+  - Useful for programmatic integrations and backend adapters
+  - Follows convention of tools like npm, apt, rm -f
+
 ## [0.4.4] - 2026-02-10
 
 ### Added

--- a/src/cli/commands/remove.ts
+++ b/src/cli/commands/remove.ts
@@ -2,7 +2,7 @@ import * as readline from 'readline/promises';
 import { stdin as input, stdout as output } from 'process';
 import { loadYAMLConfig, saveYAMLConfig, hasYAMLConfig } from '../config-yaml';
 
-export async function removeCommand(serviceName: string): Promise<void> {
+export async function removeCommand(serviceName: string, options: { yes?: boolean } = {}): Promise<void> {
   try {
     // Check for YAML config
     if (!hasYAMLConfig()) {
@@ -18,8 +18,6 @@ export async function removeCommand(serviceName: string): Promise<void> {
       process.exit(1);
     }
 
-    const rl = readline.createInterface({ input, output });
-
     // Check for capabilities using this service
     const dependentCaps = Object.entries(config.capabilities)
       .filter(([_, cap]) => cap.service === serviceName)
@@ -31,16 +29,20 @@ export async function removeCommand(serviceName: string): Promise<void> {
       console.log();
     }
 
-    // Confirm deletion
-    const answer = await rl.question(
-      `Are you sure you want to remove service "${serviceName}"? This cannot be undone. (y/N): `
-    );
+    // Confirm deletion (skip if --yes flag is set)
+    if (!options.yes) {
+      const rl = readline.createInterface({ input, output });
 
-    rl.close();
+      const answer = await rl.question(
+        `Are you sure you want to remove service "${serviceName}"? This cannot be undone. (y/N): `
+      );
 
-    if (answer.toLowerCase() !== 'y' && answer.toLowerCase() !== 'yes') {
-      console.log('❌ Cancelled');
-      return;
+      rl.close();
+
+      if (answer.toLowerCase() !== 'y' && answer.toLowerCase() !== 'yes') {
+        console.log('❌ Cancelled');
+        return;
+      }
     }
 
     // Remove service

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -22,13 +22,41 @@ function formatService(service: ServiceTemplate, verbose = false): string {
   return lines.join('\n');
 }
 
-export function searchCommand(query?: string, verbose = false): void {
+function serviceToJSON(service: ServiceTemplate) {
+  return {
+    name: service.name,
+    description: service.description,
+    baseUrl: service.baseUrl,
+    authType: service.auth.type,
+    authFields: service.auth.fields,
+    category: service.tags[0] || 'other',
+    tags: service.tags,
+    docs: service.docs
+  };
+}
+
+export function searchCommand(query?: string, options: { verbose?: boolean; json?: boolean } = {}): void {
+  const verbose = options.verbose || false;
+  const json = options.json || false;
+
   if (!query) {
-    // List all by category
+    // List all services
+    const categories = listByCategory();
+    const allServices: ServiceTemplate[] = [];
+    
+    for (const [_, services] of categories) {
+      allServices.push(...services);
+    }
+
+    if (json) {
+      console.log(JSON.stringify(allServices.map(serviceToJSON), null, 2));
+      return;
+    }
+
+    // Human-readable output
     console.log('📚 Janee Service Directory\n');
     console.log('Usage: janee search <query>\n');
     
-    const categories = listByCategory();
     for (const [category, services] of categories) {
       console.log(`\n${category.toUpperCase()}`);
       console.log('─'.repeat(40));
@@ -42,7 +70,13 @@ export function searchCommand(query?: string, verbose = false): void {
   }
 
   const results = searchDirectory(query);
-  
+
+  if (json) {
+    console.log(JSON.stringify(results.map(serviceToJSON), null, 2));
+    return;
+  }
+
+  // Human-readable output
   if (results.length === 0) {
     console.log(`No services found matching "${query}"`);
     console.log('\nRun "janee search" to see all available services');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -54,6 +54,7 @@ program
 program
   .command('remove <service>')
   .description('Remove a service from Janee')
+  .option('-y, --yes', 'Skip confirmation prompt')
   .action(removeCommand);
 
 program
@@ -91,6 +92,7 @@ program
   .command('search [query]')
   .description('Search the service directory')
   .option('-v, --verbose', 'Show full details for each service')
-  .action((query, options) => searchCommand(query, options.verbose));
+  .option('--json', 'Output as JSON')
+  .action((query, options) => searchCommand(query, options));
 
 program.parse();


### PR DESCRIPTION
## Problems

### Issue #36: Non-interactive `janee remove`
`janee remove <service>` requires interactive confirmation. When invoked programmatically (e.g., from The Office plugin backend), there's no way to skip the prompt without fragile stdin piping.

### Issue #37: Structured output for `janee search`
`janee search` only outputs human-readable text. Backend systems that need to present a service directory UI can't easily parse the output.

---

## Solutions

### `janee remove --yes` (#36)
Adds `-y, --yes` flag to skip the confirmation prompt:
```bash
janee remove myservice --yes
```

- Follows convention of `npm`, `apt`, `rm -f`
- Still shows warnings about dependent capabilities
- Useful for programmatic integrations

### `janee search --json` (#37)
Adds `--json` flag to output structured service directory data:

**With query:**
```bash
janee search stripe --json
```
```json
[
  {
    "name": "stripe",
    "description": "Payment processing platform",
    "baseUrl": "https://api.stripe.com",
    "authType": "bearer",
    "authFields": ["key"],
    "category": "payment",
    "tags": ["payment", "finance"],
    "docs": "https://stripe.com/docs/api"
  }
]
```

**Without query (full directory):**
```bash
janee search --json
```
Returns all services in the directory.

---

## Use Cases

Both features enable **The Office** virtual office app to integrate Janee:
- Backend adapter can call `janee remove <service> --yes` programmatically
- UI can build a service directory browser using `janee search --json`

---

## Testing

✅ All 102 tests pass  
✅ Manual verification:
- `janee remove testservice --yes` skips confirmation
- `janee search stripe --json` returns structured data
- `janee search --json` returns full directory
- Builds without errors

---

## Checklist

- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] README.md updated with new command examples
- [x] Closes #36
- [x] Closes #37