### PR TITLE
Add capability management CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,11 @@ janee list                    # List configured services
 janee list --json             # Output as JSON (for integrations)
 janee search [query]          # Search service directory
 janee search stripe --json    # Search with JSON output
+janee cap list                # List capabilities
+janee cap list --json         # List capabilities as JSON
+janee cap add <name> --service <service>  # Add capability
+janee cap edit <name>         # Edit capability
+janee cap remove <name>       # Remove capability
 janee serve                   # Start MCP server
 janee logs                    # View audit log
 janee logs -f                 # Tail audit log

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Capability Management Commands** — New `janee cap` subcommand group for managing capabilities independently (#39)
+  - `janee cap list` — List all capabilities (supports `--json`)
+  - `janee cap add <name> --service <service>` — Add capability with TTL, auto-approve, rules
+  - `janee cap edit <name>` — Edit existing capability (TTL, auto-approve, rules)
+  - `janee cap remove <name>` — Remove capability without removing parent service (supports `--yes`)
+  - Enables creating multiple capabilities per service (e.g., read-only, admin)
+  - Allows fine-grained control of TTL and allow/deny rules per capability
+  - Supports programmatic management via JSON output
+
 ## [0.4.5] - 2026-02-10
 
 ### Added

--- a/src/cli/commands/capability.ts
+++ b/src/cli/commands/capability.ts
@@ -1,0 +1,279 @@
+/**
+ * Capability management commands
+ */
+
+import { loadYAMLConfig, saveYAMLConfig, hasYAMLConfig, CapabilityConfig } from '../config-yaml';
+
+export async function capabilityListCommand(options: { json?: boolean } = {}): Promise<void> {
+  try {
+    if (!hasYAMLConfig()) {
+      if (options.json) {
+        console.log(JSON.stringify({ error: 'No config found' }, null, 2));
+      } else {
+        console.log('No config found. Run `janee init` first.');
+      }
+      process.exit(1);
+    }
+
+    const config = loadYAMLConfig();
+    const capabilityNames = Object.keys(config.capabilities);
+
+    if (options.json) {
+      // JSON output
+      const capabilities = capabilityNames.map(name => {
+        const cap = config.capabilities[name];
+        return {
+          name,
+          service: cap.service,
+          ttl: cap.ttl,
+          autoApprove: cap.autoApprove,
+          requiresReason: cap.requiresReason,
+          allowRules: cap.rules?.allow || [],
+          denyRules: cap.rules?.deny || []
+        };
+      });
+
+      console.log(JSON.stringify({ capabilities }, null, 2));
+      return;
+    }
+
+    // Human-readable output
+    if (capabilityNames.length === 0) {
+      console.log('No capabilities configured yet.');
+      console.log('');
+      console.log('Add a capability:');
+      console.log('  janee cap add <name> --service <service>');
+      return;
+    }
+
+    console.log('');
+    console.log('Capabilities:');
+    for (const name of capabilityNames) {
+      const cap = config.capabilities[name];
+      const allowCount = cap.rules?.allow?.length || 0;
+      const denyCount = cap.rules?.deny?.length || 0;
+      const rules = allowCount + denyCount > 0 ? ` [${allowCount} allow, ${denyCount} deny]` : '';
+      
+      console.log(`  ${name}`);
+      console.log(`    Service: ${cap.service}`);
+      console.log(`    TTL: ${cap.ttl}`);
+      if (cap.autoApprove !== undefined) {
+        console.log(`    Auto-approve: ${cap.autoApprove}`);
+      }
+      if (cap.requiresReason !== undefined) {
+        console.log(`    Requires reason: ${cap.requiresReason}`);
+      }
+      if (rules) {
+        console.log(`    Rules: ${rules}`);
+      }
+      console.log('');
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      if (options.json) {
+        console.log(JSON.stringify({ error: error.message }, null, 2));
+      } else {
+        console.error('❌ Error:', error.message);
+      }
+    } else {
+      if (options.json) {
+        console.log(JSON.stringify({ error: 'Unknown error occurred' }, null, 2));
+      } else {
+        console.error('❌ Unknown error occurred');
+      }
+    }
+    process.exit(1);
+  }
+}
+
+export async function capabilityAddCommand(
+  name: string,
+  options: {
+    service?: string;
+    ttl?: string;
+    autoApprove?: boolean;
+    requiresReason?: boolean;
+    allow?: string[];
+    deny?: string[];
+  }
+): Promise<void> {
+  try {
+    if (!hasYAMLConfig()) {
+      console.error('❌ No config found. Run `janee init` first.');
+      process.exit(1);
+    }
+
+    const config = loadYAMLConfig();
+
+    // Check if capability already exists
+    if (config.capabilities[name]) {
+      console.error(`❌ Capability "${name}" already exists. Use 'janee cap edit' to modify it.`);
+      process.exit(1);
+    }
+
+    // Service is required
+    if (!options.service) {
+      console.error('❌ --service is required');
+      process.exit(1);
+    }
+
+    // Check if service exists
+    if (!config.services[options.service]) {
+      console.error(`❌ Service "${options.service}" not found. Add it first with 'janee add'.`);
+      process.exit(1);
+    }
+
+    // Create capability
+    const capability: CapabilityConfig = {
+      service: options.service,
+      ttl: options.ttl || '1h',
+      autoApprove: options.autoApprove,
+      requiresReason: options.requiresReason
+    };
+
+    // Add rules if provided
+    if (options.allow || options.deny) {
+      capability.rules = {};
+      if (options.allow) {
+        capability.rules.allow = options.allow;
+      }
+      if (options.deny) {
+        capability.rules.deny = options.deny;
+      }
+    }
+
+    config.capabilities[name] = capability;
+    saveYAMLConfig(config);
+
+    console.log(`✅ Added capability "${name}"`);
+    console.log(`   Service: ${capability.service}`);
+    console.log(`   TTL: ${capability.ttl}`);
+
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('❌ Error:', error.message);
+    } else {
+      console.error('❌ Unknown error occurred');
+    }
+    process.exit(1);
+  }
+}
+
+export async function capabilityEditCommand(
+  name: string,
+  options: {
+    ttl?: string;
+    autoApprove?: boolean;
+    requiresReason?: boolean;
+    allow?: string[];
+    deny?: string[];
+    clearRules?: boolean;
+  }
+): Promise<void> {
+  try {
+    if (!hasYAMLConfig()) {
+      console.error('❌ No config found. Run `janee init` first.');
+      process.exit(1);
+    }
+
+    const config = loadYAMLConfig();
+
+    // Check if capability exists
+    if (!config.capabilities[name]) {
+      console.error(`❌ Capability "${name}" not found`);
+      process.exit(1);
+    }
+
+    const capability = config.capabilities[name];
+
+    // Update fields if provided
+    if (options.ttl) {
+      capability.ttl = options.ttl;
+    }
+    if (options.autoApprove !== undefined) {
+      capability.autoApprove = options.autoApprove;
+    }
+    if (options.requiresReason !== undefined) {
+      capability.requiresReason = options.requiresReason;
+    }
+
+    // Handle rules
+    if (options.clearRules) {
+      delete capability.rules;
+    } else if (options.allow || options.deny) {
+      if (!capability.rules) {
+        capability.rules = {};
+      }
+      if (options.allow) {
+        capability.rules.allow = options.allow;
+      }
+      if (options.deny) {
+        capability.rules.deny = options.deny;
+      }
+    }
+
+    saveYAMLConfig(config);
+
+    console.log(`✅ Updated capability "${name}"`);
+
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('❌ Error:', error.message);
+    } else {
+      console.error('❌ Unknown error occurred');
+    }
+    process.exit(1);
+  }
+}
+
+export async function capabilityRemoveCommand(
+  name: string,
+  options: { yes?: boolean } = {}
+): Promise<void> {
+  try {
+    if (!hasYAMLConfig()) {
+      console.error('❌ No config found. Run `janee init` first.');
+      process.exit(1);
+    }
+
+    const config = loadYAMLConfig();
+
+    // Check if capability exists
+    if (!config.capabilities[name]) {
+      console.error(`❌ Capability "${name}" not found`);
+      process.exit(1);
+    }
+
+    // Confirm deletion (skip if --yes flag is set)
+    if (!options.yes) {
+      const readline = await import('readline/promises');
+      const { stdin: input, stdout: output } = await import('process');
+      const rl = readline.createInterface({ input, output });
+
+      const answer = await rl.question(
+        `Are you sure you want to remove capability "${name}"? (y/N): `
+      );
+
+      rl.close();
+
+      if (answer.toLowerCase() !== 'y' && answer.toLowerCase() !== 'yes') {
+        console.log('❌ Cancelled');
+        return;
+      }
+    }
+
+    // Remove capability
+    delete config.capabilities[name];
+    saveYAMLConfig(config);
+
+    console.log(`✅ Capability "${name}" removed successfully!`);
+
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('❌ Error:', error.message);
+    } else {
+      console.error('❌ Unknown error occurred');
+    }
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,12 @@ import { logsCommand } from './commands/logs';
 import { sessionsCommand } from './commands/sessions';
 import { revokeCommand } from './commands/revoke';
 import { searchCommand } from './commands/search';
+import {
+  capabilityListCommand,
+  capabilityAddCommand,
+  capabilityEditCommand,
+  capabilityRemoveCommand
+} from './commands/capability';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -94,5 +100,46 @@ program
   .option('-v, --verbose', 'Show full details for each service')
   .option('--json', 'Output as JSON')
   .action((query, options) => searchCommand(query, options));
+
+// Capability management subcommands
+const cap = program.command('cap').description('Manage capabilities');
+
+cap
+  .command('list')
+  .description('List all capabilities')
+  .option('--json', 'Output as JSON')
+  .action(capabilityListCommand);
+
+cap
+  .command('add <name>')
+  .description('Add a new capability')
+  .requiredOption('-s, --service <service>', 'Service to use')
+  .option('-t, --ttl <duration>', 'TTL (e.g., 1h, 30m)', '1h')
+  .option('--auto-approve', 'Auto-approve requests')
+  .option('--no-auto-approve', 'Require manual approval')
+  .option('--requires-reason', 'Require reason for requests')
+  .option('--no-requires-reason', 'Do not require reason')
+  .option('--allow <pattern...>', 'Allow rules (e.g., "GET /v1/*")')
+  .option('--deny <pattern...>', 'Deny rules (e.g., "DELETE *")')
+  .action(capabilityAddCommand);
+
+cap
+  .command('edit <name>')
+  .description('Edit an existing capability')
+  .option('-t, --ttl <duration>', 'Update TTL (e.g., 1h, 30m)')
+  .option('--auto-approve', 'Enable auto-approve')
+  .option('--no-auto-approve', 'Disable auto-approve')
+  .option('--requires-reason', 'Require reason for requests')
+  .option('--no-requires-reason', 'Do not require reason')
+  .option('--allow <pattern...>', 'Replace allow rules')
+  .option('--deny <pattern...>', 'Replace deny rules')
+  .option('--clear-rules', 'Clear all rules')
+  .action(capabilityEditCommand);
+
+cap
+  .command('remove <name>')
+  .description('Remove a capability')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .action(capabilityRemoveCommand);
 
 program.parse();


### PR DESCRIPTION
## Problem

Capabilities are a core concept in Janee (TTL, allow/deny rules, service reference), but there's no way to manage them independently via the CLI.

**Currently:**
- `janee add` creates a service + auto-creates a capability with the same name
- `janee remove` deletes a service + all dependent capabilities
- No way to add multiple capabilities per service
- No way to edit capability TTL/rules without manual config editing
- No way to remove a capability without removing its parent service

## Solution

New `janee cap` subcommand group with four actions:

### `janee cap list [--json]`
List all capabilities with details:
```bash
janee cap list
```
```
Capabilities:
  readonly
    Service: stripe
    TTL: 1h
    Rules:  [2 allow, 1 deny]
```

JSON output:
```bash
janee cap list --json
```
```json
{
  "capabilities": [
    {
      "name": "readonly",
      "service": "stripe",
      "ttl": "1h",
      "autoApprove": true,
      "requiresReason": false,
      "allowRules": ["GET /v1/*", "GET /v2/*"],
      "denyRules": ["DELETE *"]
    }
  ]
}
```

### `janee cap add <name> --service <service>`
Create a new capability for an existing service:
```bash
# Basic capability
janee cap add readonly --service stripe --ttl 1h

# With rules
janee cap add readonly --service stripe --ttl 1h \
  --allow "GET /v1/*" --allow "GET /v2/*" \
  --deny "DELETE *" \
  --auto-approve

# Admin capability for same service
janee cap add admin --service stripe --ttl 30m --requires-reason
```

**Options:**
- `-s, --service <service>` (required) — Service to use
- `-t, --ttl <duration>` — TTL (default: 1h)
- `--auto-approve` / `--no-auto-approve` — Auto-approve requests
- `--requires-reason` / `--no-requires-reason` — Require reason
- `--allow <pattern...>` — Allow rules (repeatable)
- `--deny <pattern...>` — Deny rules (repeatable)

### `janee cap edit <name>`
Modify an existing capability:
```bash
# Update TTL
janee cap edit readonly --ttl 2h

# Update rules
janee cap edit readonly --allow "GET /v1/*" --deny "POST *"

# Clear all rules
janee cap edit readonly --clear-rules

# Toggle auto-approve
janee cap edit readonly --no-auto-approve
```

**Options:**
- `-t, --ttl <duration>` — Update TTL
- `--auto-approve` / `--no-auto-approve` — Toggle auto-approve
- `--requires-reason` / `--no-requires-reason` — Toggle reason requirement
- `--allow <pattern...>` — Replace allow rules
- `--deny <pattern...>` — Replace deny rules
- `--clear-rules` — Clear all rules

### `janee cap remove <name> [--yes]`
Remove a capability without removing its parent service:
```bash
janee cap remove readonly
janee cap remove readonly --yes  # Skip confirmation
```

---

## Use Cases

**1. Multiple capabilities per service**
Create read-only and admin capabilities for the same service:
```bash
janee cap add stripe-readonly --service stripe --ttl 24h --allow "GET *"
janee cap add stripe-admin --service stripe --ttl 15m --requires-reason
```

**2. Fine-tune rules**
Adjust allow/deny rules without recreating the capability:
```bash
janee cap edit api-access --allow "GET /public/*" --deny "DELETE *"
```

**3. Temporary capability removal**
Remove a capability for maintenance without removing the service:
```bash
janee cap remove payment-processing
# Service still exists, can add capability back later
```

**4. Programmatic management (The Office plugin)**
The Office UI can now:
- Display capabilities independently from services
- Allow users to create/edit/remove capabilities via UI
- Use `--json` output for structured data

---

## Testing

✅ All 102 tests pass  
✅ Manual verification:
- `janee cap list` / `--json` works
- `janee cap add` creates capability with rules
- `janee cap edit` updates TTL, auto-approve, rules
- `janee cap remove --yes` removes capability
- Service validation works (rejects non-existent service)
- Duplicate capability names rejected

---

## Checklist

- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] README.md updated with new commands
- [x] Closes #39