### PR TITLE
Remove Binance from directory, clarify 'hmac' auth type

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Service Directory** — Remove Binance from directory (incompatible auth scheme)
+  - Binance was listed with `hmac` auth type but requires different signing than MEXC
+  - Generic `hmac` type is for MEXC-style query-string signing (signature as URL param)
+  - Clarified auth type documentation in code comments
+  - MEXC remains in directory with correct `hmac` auth type
+
 ## [0.5.0] - 2026-02-10
 
 ### Added

--- a/src/cli/commands/serve-mcp.ts
+++ b/src/cli/commands/serve-mcp.ts
@@ -98,7 +98,7 @@ export async function serveMCPCommand(): Promise<void> {
         } else if (serviceConfig.auth.type === 'headers' && serviceConfig.auth.headers) {
           Object.assign(headers, serviceConfig.auth.headers);
         } else if (serviceConfig.auth.type === 'hmac' && serviceConfig.auth.apiKey && serviceConfig.auth.apiSecret) {
-          // MEXC-style HMAC - signature in URL params
+          // Generic HMAC - signs query string, adds signature as URL param (MEXC, etc.)
           const result = signMEXC({
             apiKey: serviceConfig.auth.apiKey,
             apiSecret: serviceConfig.auth.apiSecret,

--- a/src/core/directory.ts
+++ b/src/core/directory.ts
@@ -16,6 +16,11 @@ export interface ServiceTemplate {
   tags: string[];
 }
 
+// Auth type notes:
+// - 'hmac': Generic query-string signing (MEXC-style) - signs query string, adds signature as URL param
+// - 'hmac-bybit': Bybit-specific HMAC variant - signature in headers
+// - 'hmac-okx': OKX-specific HMAC variant - requires passphrase, base64 encoded
+
 /**
  * Built-in service directory
  */
@@ -113,14 +118,6 @@ export const serviceDirectory: ServiceTemplate[] = [
     baseUrl: 'https://api.mexc.com',
     auth: { type: 'hmac', fields: ['apiKey', 'apiSecret'] },
     docs: 'https://mexcdevelop.github.io/apidocs',
-    tags: ['crypto', 'exchange', 'trading']
-  },
-  {
-    name: 'binance',
-    description: 'Largest cryptocurrency exchange',
-    baseUrl: 'https://api.binance.com',
-    auth: { type: 'hmac', fields: ['apiKey', 'apiSecret'] },
-    docs: 'https://binance-docs.github.io/apidocs',
     tags: ['crypto', 'exchange', 'trading']
   },
   {

--- a/src/core/signing.ts
+++ b/src/core/signing.ts
@@ -36,6 +36,9 @@ export interface MEXCSigningParams {
   timestamp?: string;
 }
 
+// Note: MEXCSigningParams is used for generic 'hmac' auth type
+// (query-string signing pattern used by MEXC and similar exchanges)
+
 /**
  * Bybit HMAC signing
  * - GET/DELETE: sign timestamp + apiKey + recvWindow + queryString
@@ -92,8 +95,10 @@ export function signOKX(params: OKXSigningParams): SigningResult {
 }
 
 /**
- * MEXC HMAC signing
- * - Signs query string, adds signature as URL param
+ * Generic HMAC signing (MEXC-style)
+ * - Signs query string with timestamp
+ * - Returns signature as URL param and API key as header
+ * - Used by MEXC and other exchanges with similar auth schemes
  */
 export function signMEXC(params: MEXCSigningParams): SigningResult {
   const timestamp = params.timestamp || Date.now().toString();


### PR DESCRIPTION
## Problem

Binance was listed in the service directory with `hmac` auth type, but Binance's HMAC signing scheme is **different** from MEXC's (the reference implementation for the generic `hmac` type).

**Current behavior:**
- `janee add binance` would create a service with `type: 'hmac'`
- Requests would use MEXC-style signing (query-string + signature as URL param)
- **Binance API would reject the requests** due to incompatible auth

## Solution

### 1. Remove Binance from directory
Binance removed until we add proper `hmac-binance` support (if needed).

### 2. Clarify `hmac` auth type documentation
Added comments throughout the codebase:

**In `directory.ts`:**
```typescript
// Auth type notes:
// - 'hmac': Generic query-string signing (MEXC-style)
// - 'hmac-bybit': Bybit-specific HMAC variant
// - 'hmac-okx': OKX-specific HMAC variant (passphrase + base64)
```

**In `signing.ts`:**
```typescript
/**
 * Generic HMAC signing (MEXC-style)
 * - Signs query string with timestamp
 * - Returns signature as URL param and API key as header
 * - Used by MEXC and other exchanges with similar auth schemes
 */
export function signMEXC(params: MEXCSigningParams): SigningResult
```

**In `serve-mcp.ts`:**
```typescript
// Generic HMAC - signs query string, adds signature as URL param (MEXC, etc.)
```

## What Still Works

- **MEXC** — Correctly configured with `hmac` type ✅
- **Bybit** — Uses `hmac-bybit` type ✅
- **OKX** — Uses `hmac-okx` type ✅
- **Coinbase** — Uses `bearer` type ✅

Users can still add Binance manually with custom config if they know the correct signing scheme.

## Testing

✅ All 102 tests pass  
✅ `janee search binance` returns "No services found" (correct)  
✅ `janee search mexc` finds MEXC with `hmac` auth type  
✅ Build succeeds

## Checklist

- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Auth type documentation clarified in code comments