### PR TITLE
Rename 'hmac' auth type to 'hmac-mexc' for clarity [BREAKING]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,15 +4,21 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Auth Types** — Rename `hmac` to `hmac-mexc` for clarity
+  - MEXC now explicitly uses `hmac-mexc` auth type
+  - Removes ambiguity about which HMAC scheme is used
+  - Each exchange has explicit auth type: `hmac-mexc`, `hmac-bybit`, `hmac-okx`
+  - **Breaking change**: Existing configs with `type: 'hmac'` need to be updated to `type: 'hmac-mexc'`
+
 ## [0.5.1] - 2026-02-10
 
 ### Fixed
 
 - **Service Directory** — Remove Binance from directory (incompatible auth scheme)
   - Binance was listed with `hmac` auth type but requires different signing than MEXC
-  - Generic `hmac` type is for MEXC-style query-string signing (signature as URL param)
   - Clarified auth type documentation in code comments
-  - MEXC remains in directory with correct `hmac` auth type
 
 ## [0.5.0] - 2026-02-10
 

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -127,7 +127,7 @@ export async function addCommand(
     }
 
     let baseUrl: string;
-    let authType: 'bearer' | 'basic' | 'hmac' | 'hmac-bybit' | 'hmac-okx' | 'headers' | 'service-account';
+    let authType: 'bearer' | 'basic' | 'hmac-mexc' | 'hmac-bybit' | 'hmac-okx' | 'headers' | 'service-account';
 
     if (template) {
       // Use template from directory
@@ -183,7 +183,7 @@ export async function addCommand(
             },
             {
               name: 'hmac — Request signing (generic)',
-              value: 'hmac',
+              value: 'hmac-mexc',
               description: 'HMAC-based request signing with API key + secret'
             },
             {
@@ -246,7 +246,7 @@ export async function addCommand(
         type: 'bearer',
         key: `Basic ${encoded}`
       };
-    } else if (authType === 'hmac' || authType === 'hmac-bybit') {
+    } else if (authType === 'hmac-mexc' || authType === 'hmac-bybit') {
       let apiKey = options.key;
       let apiSecret = options.apiSecret;
 

--- a/src/cli/commands/serve-mcp.ts
+++ b/src/cli/commands/serve-mcp.ts
@@ -97,8 +97,8 @@ export async function serveMCPCommand(): Promise<void> {
           headers['Authorization'] = `Bearer ${serviceConfig.auth.key}`;
         } else if (serviceConfig.auth.type === 'headers' && serviceConfig.auth.headers) {
           Object.assign(headers, serviceConfig.auth.headers);
-        } else if (serviceConfig.auth.type === 'hmac' && serviceConfig.auth.apiKey && serviceConfig.auth.apiSecret) {
-          // Generic HMAC - signs query string, adds signature as URL param (MEXC, etc.)
+        } else if (serviceConfig.auth.type === 'hmac-mexc' && serviceConfig.auth.apiKey && serviceConfig.auth.apiSecret) {
+          // MEXC HMAC - signs query string, adds signature as URL param
           const result = signMEXC({
             apiKey: serviceConfig.auth.apiKey,
             apiSecret: serviceConfig.auth.apiSecret,

--- a/src/cli/config-yaml.test.ts
+++ b/src/cli/config-yaml.test.ts
@@ -300,7 +300,7 @@ describe('Config YAML', () => {
           hmacService: {
             baseUrl: 'https://api2.com',
             auth: { 
-              type: 'hmac', 
+              type: 'hmac-mexc', 
               apiKey: 'hmac-key',
               apiSecret: 'hmac-secret'
             }

--- a/src/cli/config-yaml.ts
+++ b/src/cli/config-yaml.ts
@@ -10,7 +10,7 @@ import yaml from 'js-yaml';
 import { encryptSecret, decryptSecret, generateMasterKey } from '../core/crypto';
 
 export interface AuthConfig {
-  type: 'bearer' | 'hmac' | 'hmac-bybit' | 'hmac-okx' | 'headers' | 'service-account';
+  type: 'bearer' | 'hmac-mexc' | 'hmac-bybit' | 'hmac-okx' | 'headers' | 'service-account';
   key?: string;
   apiKey?: string;
   apiSecret?: string;
@@ -146,7 +146,7 @@ export function loadYAMLConfig(): JaneeYAMLConfig {
         strictDecryption,
         `bearer token for service "${name}"`
       );
-    } else if (svc.auth.type === 'hmac' || svc.auth.type === 'hmac-bybit' || svc.auth.type === 'hmac-okx') {
+    } else if (svc.auth.type === 'hmac-mexc' || svc.auth.type === 'hmac-bybit' || svc.auth.type === 'hmac-okx') {
       if (svc.auth.apiKey) {
         svc.auth.apiKey = tryDecrypt(
           svc.auth.apiKey,
@@ -205,7 +205,7 @@ export function saveYAMLConfig(config: JaneeYAMLConfig): void {
     const svc = service as ServiceConfig;
     if (svc.auth.type === 'bearer' && svc.auth.key) {
       svc.auth.key = encryptSecret(svc.auth.key, config.masterKey);
-    } else if (svc.auth.type === 'hmac' || svc.auth.type === 'hmac-bybit' || svc.auth.type === 'hmac-okx') {
+    } else if (svc.auth.type === 'hmac-mexc' || svc.auth.type === 'hmac-bybit' || svc.auth.type === 'hmac-okx') {
       if (svc.auth.apiKey) {
         svc.auth.apiKey = encryptSecret(svc.auth.apiKey, config.masterKey);
       }

--- a/src/core/directory.test.ts
+++ b/src/core/directory.test.ts
@@ -88,7 +88,7 @@ describe('Service Directory', () => {
     });
 
     it('all services should have valid auth types', () => {
-      const validTypes = ['bearer', 'basic', 'hmac', 'hmac-bybit', 'hmac-okx', 'headers'];
+      const validTypes = ['bearer', 'basic', 'hmac-mexc', 'hmac-bybit', 'hmac-okx', 'headers'];
       for (const service of serviceDirectory) {
         expect(validTypes).toContain(service.auth.type);
       }

--- a/src/core/directory.ts
+++ b/src/core/directory.ts
@@ -9,7 +9,7 @@ export interface ServiceTemplate {
   description: string;
   baseUrl: string;
   auth: {
-    type: 'bearer' | 'basic' | 'hmac' | 'hmac-bybit' | 'hmac-okx' | 'headers';
+    type: 'bearer' | 'basic' | 'hmac-mexc' | 'hmac-bybit' | 'hmac-okx' | 'headers';
     fields: string[];  // Required fields to prompt for
   };
   docs?: string;
@@ -17,9 +17,9 @@ export interface ServiceTemplate {
 }
 
 // Auth type notes:
-// - 'hmac': Generic query-string signing (MEXC-style) - signs query string, adds signature as URL param
-// - 'hmac-bybit': Bybit-specific HMAC variant - signature in headers
-// - 'hmac-okx': OKX-specific HMAC variant - requires passphrase, base64 encoded
+// - 'hmac-mexc': MEXC-specific HMAC - signs query string, adds signature as URL param
+// - 'hmac-bybit': Bybit-specific HMAC - signature in headers
+// - 'hmac-okx': OKX-specific HMAC - requires passphrase, base64 encoded
 
 /**
  * Built-in service directory
@@ -116,7 +116,7 @@ export const serviceDirectory: ServiceTemplate[] = [
     name: 'mexc',
     description: 'Cryptocurrency exchange',
     baseUrl: 'https://api.mexc.com',
-    auth: { type: 'hmac', fields: ['apiKey', 'apiSecret'] },
+    auth: { type: 'hmac-mexc', fields: ['apiKey', 'apiSecret'] },
     docs: 'https://mexcdevelop.github.io/apidocs',
     tags: ['crypto', 'exchange', 'trading']
   },

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -29,7 +29,7 @@ export interface Capability {
 export interface ServiceConfig {
   baseUrl: string;
   auth: {
-    type: 'bearer' | 'hmac' | 'hmac-bybit' | 'hmac-okx' | 'headers' | 'service-account';
+    type: 'bearer' | 'hmac-mexc' | 'hmac-bybit' | 'hmac-okx' | 'headers' | 'service-account';
     key?: string;
     apiKey?: string;
     apiSecret?: string;

--- a/src/core/signing.ts
+++ b/src/core/signing.ts
@@ -36,9 +36,6 @@ export interface MEXCSigningParams {
   timestamp?: string;
 }
 
-// Note: MEXCSigningParams is used for generic 'hmac' auth type
-// (query-string signing pattern used by MEXC and similar exchanges)
-
 /**
  * Bybit HMAC signing
  * - GET/DELETE: sign timestamp + apiKey + recvWindow + queryString
@@ -95,10 +92,9 @@ export function signOKX(params: OKXSigningParams): SigningResult {
 }
 
 /**
- * Generic HMAC signing (MEXC-style)
+ * MEXC HMAC signing
  * - Signs query string with timestamp
- * - Returns signature as URL param and API key as header
- * - Used by MEXC and other exchanges with similar auth schemes
+ * - Returns signature as URL param and API key as header (X-MEXC-APIKEY)
  */
 export function signMEXC(params: MEXCSigningParams): SigningResult {
   const timestamp = params.timestamp || Date.now().toString();


### PR DESCRIPTION
## Problem

The generic `hmac` auth type was ambiguous and MEXC-specific in implementation, which could cause confusion:
- Users might expect "hmac" to be a standard HMAC pattern
- Reality: Every exchange has its own HMAC scheme (MEXC, Bybit, OKX all differ)
- The `hmac` type only worked for MEXC-style signing

## Solution

**BREAKING CHANGE:** Rename `hmac` → `hmac-mexc`

This makes auth types explicit and unambiguous:
- `hmac-mexc` — MEXC (signs query string, signature as URL param)
- `hmac-bybit` — Bybit (signature in headers)
- `hmac-okx` — OKX (passphrase + base64)

Each exchange now has an explicitly named auth type.

## Changes

- Update `ServiceTemplate` type union in directory.ts
- Update MEXC directory entry to use `hmac-mexc`
- Update serve-mcp.ts auth handling
- Update all type declarations across codebase (mcp-server.ts, config-yaml.ts, add.ts)
- Update tests (directory.test.ts, config-yaml.test.ts)
- Update signing.ts documentation

## Migration Path

Existing configs with `type: 'hmac'` need manual update:

```yaml
# Before
services:
  mexc:
    baseUrl: https://api.mexc.com
    auth:
      type: hmac  # Old
      apiKey: "..."
      apiSecret: "..."

# After
services:
  mexc:
    baseUrl: https://api.mexc.com
    auth:
      type: hmac-mexc  # New
      apiKey: "..."
      apiSecret: "..."
```

## Testing

✅ All 102 tests pass  
✅ `janee search mexc` shows `hmac-mexc` auth type  
✅ Build succeeds

## Checklist

- [x] Tests pass
- [x] CHANGELOG.md updated (marked as BREAKING CHANGE)
- [x] Migration path documented