### PR TITLE
Fix MEXC auth: include path+query in HTTP request options

### DIFF
--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -328,11 +328,14 @@ export function makeAPIRequest(
     const client = targetUrl.protocol === 'https:' ? https : http;
 
     const options = {
+      hostname: targetUrl.hostname,
+      port: targetUrl.port,
+      path: targetUrl.pathname + targetUrl.search,
       method: request.method,
       headers: request.headers
     };
 
-    const req = client.request(targetUrl, options, (res) => {
+    const req = client.request(options, (res) => {
       let body = '';
 
       res.on('data', (chunk) => {


### PR DESCRIPTION
## Bug

MEXC API calls through Janee were failing with:
```
{"code":400,"msg":"api key required"}
```

Despite:
- ✅ Config loading correctly
- ✅ Keys decrypting correctly  
- ✅ HMAC signing working correctly
- ✅ Direct API test (outside Janee) succeeding

## Root Cause

`makeAPIRequest()` was passing **both** a URL object and an options object to `http.request()`:
```typescript
const req = client.request(targetUrl, options, (res) => {
```

The options object only had `method` and `headers`, but **not** `path`. When Node.js `http.request(url, options)` receives both arguments, it uses `options.path` if present. Since we didn't set it, the URL's pathname and search params (including `?timestamp=...&signature=...`) were **lost**.

## Fix

Explicitly construct options with:
```typescript
const options = {
  hostname: targetUrl.hostname,
  port: targetUrl.port,
  path: targetUrl.pathname + targetUrl.search,  // ← Critical!
  method: request.method,
  headers: request.headers
};

const req = client.request(options, (res) => {
```

This ensures query parameters (timestamp, signature) are included in the HTTP request.

## Testing

✅ Direct test with fixed `makeAPIRequest`: **Status 200**
```
Status: 200
Body: {"makerCommission":null,..."balances":[{"asset":"USDT","free":"101.27971426295965"...
```

✅ All other exchanges (OKX, Bybit) unaffected — they use headers for auth, not URL params

## Impact

- Fixes MEXC API access through Janee
- No impact on other exchanges
- No breaking changes