### PR TITLE
docs: add Claude Desktop quickstart and multi-agent setup guides

### DIFF
--- a/examples/claude-desktop/README.md
+++ b/examples/claude-desktop/README.md
@@ -1,0 +1,121 @@
+# Using Janee with Claude Desktop
+
+A step-by-step guide to setting up Janee as your secrets manager for Claude Desktop.
+
+## Why?
+
+When Claude Desktop connects to MCP servers that need API keys (GitHub, Stripe, OpenAI, etc.), you typically hardcode those keys in your Claude Desktop config. This means:
+
+- Keys are stored in plaintext in `claude_desktop_config.json`
+- Every MCP server gets its own copy of your keys
+- No audit trail of which keys were used when
+- No way to rotate keys centrally
+
+**Janee fixes this.** Store your keys once, encrypted, and let Claude access them through MCP — with full audit logging.
+
+## Setup (2 minutes)
+
+### 1. Install Janee
+
+```bash
+npm install -g @true-and-useful/janee
+janee init
+```
+
+### 2. Add your API keys
+
+```bash
+# Interactive mode
+janee add
+
+# Or directly
+janee add github --auth bearer --key ghp_yourtoken
+janee add stripe --auth bearer --key sk_live_yourkey
+janee add openai --auth bearer --key sk-yourkey
+```
+
+### 3. Configure Claude Desktop
+
+Add Janee to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "janee": {
+      "command": "janee",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+On macOS, this file is at: `~/Library/Application Support/Claude/claude_desktop_config.json`
+On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+### 4. Restart Claude Desktop
+
+That's it. Claude can now use your APIs through Janee.
+
+## Usage Examples
+
+Once configured, you can ask Claude things like:
+
+- *"Check my recent GitHub notifications"* — Claude uses your GitHub key via Janee
+- *"List my Stripe customers"* — Claude uses your Stripe key via Janee
+- *"Send an email via my Gmail"* — Claude uses your Gmail key via Janee
+
+All requests are proxied through Janee, so:
+- ✅ Claude never sees the raw API key
+- ✅ Every API call is logged in `~/.janee/audit.log`
+- ✅ You can revoke access instantly with `janee remove <service>`
+
+## Viewing Audit Logs
+
+```bash
+# See recent API calls made by Claude
+janee audit
+
+# Filter by service
+janee audit --service github
+
+# Export as JSON
+janee audit --format json
+```
+
+## Multiple Agents, One Config
+
+The best part: if you also use Cursor, Windsurf, or any other MCP client, just point them at Janee too. **One set of keys, every agent, full visibility.**
+
+```json
+// cursor mcp config
+{
+  "janee": {
+    "command": "janee",
+    "args": ["serve"]
+  }
+}
+```
+
+## Security Notes
+
+- Keys are encrypted at rest using AES-256-GCM in `~/.janee/`
+- The encryption key is derived from your system keychain (macOS) or a local passphrase
+- Janee runs locally — your keys never leave your machine
+- Audit logs capture timestamps, service accessed, and request metadata (not response bodies)
+
+## Troubleshooting
+
+**Claude says "Janee is not available"**
+- Make sure `janee serve` works from your terminal
+- Check that the path to `janee` is in your system PATH
+- Restart Claude Desktop after config changes
+
+**Keys not working**
+- Verify with `janee list` that your service is configured
+- Test directly: `janee test github` (runs a health check against the API)
+
+## Next Steps
+
+- [Janee Documentation](https://github.com/rsdouglas/janee)
+- [MCP Protocol Spec](https://modelcontextprotocol.io)
+- [Report Issues](https://github.com/rsdouglas/janee/issues)

--- a/examples/multi-agent/README.md
+++ b/examples/multi-agent/README.md
@@ -1,0 +1,91 @@
+# Multi-Agent Setup with Janee
+
+How to use Janee across multiple AI agents simultaneously — with one set of keys and centralized audit logging.
+
+## The Problem
+
+Most developers use 2-3 AI tools daily. Each one needs API access configured separately:
+
+| Without Janee | With Janee |
+|---|---|
+| Copy keys to Claude Desktop config | Store keys once in Janee |
+| Copy keys to Cursor config | Point Claude at Janee |
+| Copy keys to Windsurf config | Point Cursor at Janee |
+| Copy keys to CLI tools | Point Windsurf at Janee |
+| Keys in 4 plaintext files | Keys in 1 encrypted vault |
+| 0 audit trail | Full audit trail |
+| Key rotation = update 4 files | Key rotation = update 1 place |
+
+## Setup
+
+### 1. Install and configure Janee once
+
+```bash
+npm install -g @true-and-useful/janee
+janee init
+janee add github --auth bearer --key ghp_xxx
+janee add stripe --auth bearer --key sk_live_xxx
+janee add openai --auth bearer --key sk-xxx
+```
+
+### 2. Add to Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json`:
+```json
+{
+  "mcpServers": {
+    "janee": { "command": "janee", "args": ["serve"] }
+  }
+}
+```
+
+### 3. Add to Cursor
+
+`.cursor/mcp.json` in your project root:
+```json
+{
+  "mcpServers": {
+    "janee": { "command": "janee", "args": ["serve"] }
+  }
+}
+```
+
+### 4. Add to any MCP client
+
+The pattern is always the same — just tell the client to run `janee serve` as an MCP server.
+
+## Audit Across Agents
+
+When multiple agents use Janee, the audit log captures which client made each request:
+
+```bash
+$ janee audit --last 5
+2026-02-12 14:23:01  claude-desktop  github    GET /user/repos
+2026-02-12 14:23:15  cursor          openai    POST /v1/chat/completions  
+2026-02-12 14:24:02  claude-desktop  stripe    GET /v1/customers
+2026-02-12 14:25:11  cursor          github    POST /repos/user/repo/issues
+2026-02-12 14:26:00  windsurf        github    GET /user/notifications
+```
+
+## Key Rotation
+
+Rotate a key once, every agent gets the update:
+
+```bash
+janee update github --key ghp_newtoken
+# Done. All agents use the new key on their next request.
+```
+
+## Access Control (Coming Soon)
+
+Future versions will support per-agent permissions:
+
+```yaml
+# ~/.janee/policies.yaml
+agents:
+  cursor:
+    allow: [github, openai]
+    deny: [stripe]  # Cursor doesn't need payment access
+  claude-desktop:
+    allow: [github, stripe, openai]
+```


### PR DESCRIPTION
## What

Adds practical getting-started guides in `examples/` to help new users adopt Janee quickly.

### `examples/claude-desktop/`
Step-by-step guide for using Janee with Claude Desktop — the most common MCP client. Covers:
- Installation and key setup
- Claude Desktop config (`claude_desktop_config.json`)
- Usage examples and audit logging
- Security notes and troubleshooting

### `examples/multi-agent/`
Guide for the "configure once, use everywhere" story — using Janee across Claude Desktop, Cursor, Windsurf, and any MCP client simultaneously. Covers:
- Before/after comparison table
- Config snippets for each client
- Cross-agent audit log examples
- Key rotation workflow
- Future access control policies

## Why

The README does a great job explaining *what* Janee is, but new users still need to figure out the exact config for their specific AI tool. These guides close that gap and make the "npm install → working setup" path as fast as possible.

## Notes
- No code changes, docs only
- Guides reference actual Janee CLI commands (`janee init`, `janee add`, `janee serve`, `janee audit`)
- Multi-agent guide previews the upcoming access control feature to build excitement