### PR TITLE
feat: add MCP Registry support for official listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@true-and-useful/janee",
+  "mcpName": "io.github.rsdouglas/janee",
   "version": "0.8.0",
   "description": "Secrets management for AI agents via MCP",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.rsdouglas/janee",
+  "description": "Secrets management for AI agents via MCP. Janee acts as a secure proxy that manages API keys and credentials so AI agents never see raw secrets — they get capability-scoped, auditable access instead.",
+  "repository": {
+    "url": "https://github.com/rsdouglas/janee",
+    "source": "github"
+  },
+  "version": "0.8.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@true-and-useful/janee",
+      "version": "0.8.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtime": "node",
+      "environmentVariables": [
+        {
+          "name": "JANEE_CONFIG",
+          "description": "Path to Janee configuration file",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## MCP Registry Support

This PR adds everything needed to publish Janee to the [official MCP Registry](https://registry.modelcontextprotocol.io) (6.4k+ ⭐).

### Changes
- **`server.json`** — Registry metadata file following the [official schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json)
- **`package.json`** — Added `mcpName` field (`io.github.rsdouglas/janee`) required for npm package verification

### Why This Matters

The MCP Registry is the canonical source that feeds into all major MCP server directories:
- **[PulseMCP](https://pulsemcp.com)** — Ingests from registry daily
- **[Glama.ai](https://glama.ai/mcp)** — Auto-syncs from registry  
- **[MCP Hub Registry](https://registry.mcphub.io)** — Tracks registry entries
- **[mcp-servers-hub](https://github.com/apappascs/mcp-servers-hub)** — Auto-generates top 100 list from aggregators

Getting listed here is the single highest-leverage distribution action for Janee.

### How to Publish (after merge)

```bash
# Install the publisher CLI
brew install mcp-publisher
# Or: curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/

# Authenticate
mcp-publisher login github

# Publish
mcp-publisher publish
```

### References
- [MCP Registry Quickstart](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx)
- [Registry API Docs](https://registry.modelcontextprotocol.io/docs)