### PR TITLE
docs: add badges, features table, and improved intro to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 **Secrets management for AI agents via MCP**
 
+[![npm version](https://img.shields.io/npm/v/@true-and-useful/janee.svg)](https://www.npmjs.com/package/@true-and-useful/janee)
+[![npm downloads](https://img.shields.io/npm/dw/@true-and-useful/janee.svg)](https://www.npmjs.com/package/@true-and-useful/janee)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![GitHub stars](https://img.shields.io/github/stars/rsdouglas/janee.svg?style=social)](https://github.com/rsdouglas/janee)
+
+> Your AI agents need API access to be useful. But they shouldn't have your raw API keys.
+> Janee sits between your agents and your APIs — injecting credentials, enforcing policies, and logging everything.
+
+
+### ✨ Features
+
+| | |
+|---|---|
+| 🔒 **Zero-knowledge agents** | Agents call APIs without ever seeing keys |
+| 📋 **Full audit trail** | Every request logged with timestamp, method, path, status |
+| 🛡️ **Request policies** | Allow/deny rules per capability (e.g., read-only Stripe) |
+| ⏱️ **Session TTLs** | Time-limited access with instant revocation |
+| 🔌 **Works with any MCP client** | Claude Desktop, Cursor, OpenClaw, and more |
+| 🏠 **Local-first** | Keys encrypted on your machine, never sent to a cloud |
+
 ---
 
 ## The Problem


### PR DESCRIPTION
## Summary

Improves the README "above the fold" experience to better convert first-time visitors into users.

## Changes

- **Badges**: npm version, weekly downloads, MIT license, GitHub stars — gives instant credibility signals
- **Blockquote intro**: One-sentence summary of what Janee does, right at the top
- **Features table**: Scannable grid of key features (zero-knowledge agents, audit trail, request policies, TTLs, MCP compatibility, local-first)

## Why

The existing README has great depth but the first thing a visitor sees is just the title and a problem statement. Adding badges and a features summary helps developers quickly assess whether Janee is relevant to them before scrolling.

No functional changes — docs only.