### PR TITLE
docs: add Claude Desktop, multi-agent, and database integration guides

### DIFF
--- a/docs/claude-desktop-quickstart.md
+++ b/docs/claude-desktop-quickstart.md
@@ -1,0 +1,121 @@
+# Using Janee with Claude Desktop
+
+A step-by-step guide to setting up Janee as your secrets manager for Claude Desktop.
+
+## Why?
+
+When Claude Desktop connects to MCP servers that need API keys (GitHub, Stripe, OpenAI, etc.), you typically hardcode those keys in your Claude Desktop config. This means:
+
+- Keys are stored in plaintext in `claude_desktop_config.json`
+- Every MCP server gets its own copy of your keys
+- No audit trail of which keys were used when
+- No way to rotate keys centrally
+
+**Janee fixes this.** Store your keys once, encrypted, and let Claude access them through MCP — with full audit logging.
+
+## Setup (2 minutes)
+
+### 1. Install Janee
+
+```bash
+npm install -g @true-and-useful/janee
+janee init
+```
+
+### 2. Add your API keys
+
+```bash
+# Interactive mode
+janee add
+
+# Or directly
+janee add github --auth bearer --key ghp_yourtoken
+janee add stripe --auth bearer --key sk_live_yourkey
+janee add openai --auth bearer --key sk-yourkey
+```
+
+### 3. Configure Claude Desktop
+
+Add Janee to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "janee": {
+      "command": "janee",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+On macOS, this file is at: `~/Library/Application Support/Claude/claude_desktop_config.json`
+On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+### 4. Restart Claude Desktop
+
+That's it. Claude can now use your APIs through Janee.
+
+## Usage Examples
+
+Once configured, you can ask Claude things like:
+
+- *"Check my recent GitHub notifications"* — Claude uses your GitHub key via Janee
+- *"List my Stripe customers"* — Claude uses your Stripe key via Janee
+- *"Send an email via my Gmail"* — Claude uses your Gmail key via Janee
+
+All requests are proxied through Janee, so:
+- ✅ Claude never sees the raw API key
+- ✅ Every API call is logged in `~/.janee/audit.log`
+- ✅ You can revoke access instantly with `janee remove <service>`
+
+## Viewing Audit Logs
+
+```bash
+# See recent API calls made by Claude
+janee audit
+
+# Filter by service
+janee audit --service github
+
+# Export as JSON
+janee audit --format json
+```
+
+## Multiple Agents, One Config
+
+The best part: if you also use Cursor, Windsurf, or any other MCP client, just point them at Janee too. **One set of keys, every agent, full visibility.**
+
+```json
+// cursor mcp config
+{
+  "janee": {
+    "command": "janee",
+    "args": ["serve"]
+  }
+}
+```
+
+## Security Notes
+
+- Keys are encrypted at rest using AES-256-GCM in `~/.janee/`
+- The encryption key is derived from your system keychain (macOS) or a local passphrase
+- Janee runs locally — your keys never leave your machine
+- Audit logs capture timestamps, service accessed, and request metadata (not response bodies)
+
+## Troubleshooting
+
+**Claude says "Janee is not available"**
+- Make sure `janee serve` works from your terminal
+- Check that the path to `janee` is in your system PATH
+- Restart Claude Desktop after config changes
+
+**Keys not working**
+- Verify with `janee list` that your service is configured
+- Test directly: `janee test github` (runs a health check against the API)
+
+## Next Steps
+
+- [Janee Documentation](https://github.com/rsdouglas/janee)
+- [MCP Protocol Spec](https://modelcontextprotocol.io)
+- [Report Issues](https://github.com/rsdouglas/janee/issues)

--- a/docs/integration-databases-mcp.md
+++ b/docs/integration-databases-mcp.md
@@ -1,0 +1,236 @@
+# Integrating Janee with Database MCP Servers
+
+Manage database credentials securely while giving AI agents read/write access to PostgreSQL, MySQL, SQLite, and Supabase through MCP.
+
+## Why Use Janee for Database Access?
+
+Database credentials are the most sensitive secrets in any stack:
+- **Connection strings** contain host, port, username, and password
+- **A leaked credential = full database access** — reads, writes, deletes
+- **Compliance frameworks** (SOC2, HIPAA) require credential rotation and audit trails
+
+Without Janee, database MCP servers require credentials in plaintext config:
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres", "postgresql://user:password@localhost:5432/mydb"]
+    }
+  }
+}
+```
+
+**Problems:**
+- ❌ Password visible in config file
+- ❌ Connection string in process arguments (visible via `ps aux`)
+- ❌ No record of which queries the agent ran
+- ❌ If config is committed to git, credentials are permanently exposed
+
+---
+
+## Architecture
+
+```
+┌──────────────┐     MCP      ┌───────┐    HTTPS    ┌────────────┐
+│  AI Agent    │ ◄──────────► │ Janee │ ──────────► │  Database  │
+│ (Claude,     │  (tools +    │       │  (injected  │  (Postgres │
+│  Cursor)     │   prompts)   │       │   creds)    │   MySQL)   │
+└──────────────┘              └───────┘             └────────────┘
+                                 │
+                          Audit log: what was
+                          accessed, when, why
+```
+
+---
+
+## Setup
+
+### 1. Install Janee
+
+```bash
+npm install -g @true-and-useful/janee
+janee init
+```
+
+### 2. Add Database Service
+
+**PostgreSQL:**
+
+```bash
+janee add service postgres \
+  --base-url "postgresql://localhost:5432/mydb" \
+  --auth-type basic \
+  --auth-key "user:password"
+```
+
+**Supabase:**
+
+```bash
+janee add service supabase \
+  --base-url "https://your-project.supabase.co/rest/v1" \
+  --auth-type bearer \
+  --auth-key "eyJhbGciOiJIUzI1NiIsInR5..."
+```
+
+**MySQL:**
+
+```bash
+janee add service mysql \
+  --base-url "mysql://localhost:3306/mydb" \
+  --auth-type basic \
+  --auth-key "root:secret"
+```
+
+### 3. Configure Your MCP Client
+
+**Claude Desktop (`claude_desktop_config.json`):**
+
+```json
+{
+  "mcpServers": {
+    "janee": {
+      "command": "janee",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+That's it. No database credentials in this file.
+
+### 4. Use It
+
+Ask your AI agent:
+
+> "Query the users table and show me the most recent signups"
+
+The agent calls Janee's `execute` tool → Janee injects the real credentials → the query runs → results come back. The agent never sees `user:password`.
+
+---
+
+## Security Best Practices
+
+### Restrict to Read-Only
+
+Create a read-only database user for agent access:
+
+```sql
+-- PostgreSQL
+CREATE ROLE agent_readonly WITH LOGIN PASSWORD 'agent_pass';
+GRANT CONNECT ON DATABASE mydb TO agent_readonly;
+GRANT USAGE ON SCHEMA public TO agent_readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO agent_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO agent_readonly;
+```
+
+Then configure Janee with this restricted user instead of your admin credentials.
+
+### Use Connection Pooling
+
+For production, point Janee at a connection pooler (PgBouncer, Supavisor) rather than directly at the database:
+
+```bash
+janee add service postgres \
+  --base-url "postgresql://pooler.example.com:6432/mydb" \
+  --auth-type basic \
+  --auth-key "agent_readonly:agent_pass"
+```
+
+### Rotate Credentials
+
+When you rotate database passwords, update once in Janee:
+
+```bash
+janee update service postgres --auth-key "agent_readonly:new_password"
+```
+
+All connected agents automatically use the new credentials. No config files to update, no agents to restart.
+
+### Review Audit Logs
+
+```bash
+janee logs --service postgres --last 24h
+```
+
+See every query the agent executed, with timestamps and context.
+
+---
+
+## Supported Database MCP Servers
+
+| Server | Package | Notes |
+|--------|---------|-------|
+| PostgreSQL | `@modelcontextprotocol/server-postgres` | Official MCP server |
+| SQLite | `@modelcontextprotocol/server-sqlite` | File-based, local only |
+| MySQL | `@benborla29/mcp-server-mysql` | Community server |
+| Supabase | `@supabase/mcp` | Includes auth + storage |
+| Neon | `@neondatabase/mcp-server-neon` | Serverless Postgres |
+
+All of these normally require credentials passed via environment variables or CLI arguments. Janee replaces that pattern with encrypted, audited secret injection.
+
+---
+
+## Example: Supabase + Janee + Claude Desktop
+
+A complete working setup:
+
+**1. Store Supabase credentials:**
+
+```bash
+janee add service supabase \
+  --base-url "https://xyzproject.supabase.co/rest/v1" \
+  --auth-type bearer \
+  --auth-key "eyJhbGciOiJIUzI1NiIs..."
+
+janee add service supabase-admin \
+  --base-url "https://xyzproject.supabase.co/rest/v1" \
+  --auth-type bearer \
+  --auth-key "eyJhbGciOiJIUzI1NiIs..." \
+```
+
+**2. Claude Desktop config:**
+
+```json
+{
+  "mcpServers": {
+    "janee": {
+      "command": "janee",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+**3. Talk to Claude:**
+
+> "Show me all users who signed up in the last week from the supabase service"
+
+Claude uses Janee → Janee authenticates with Supabase → results returned → credentials never exposed.
+
+---
+
+## Troubleshooting
+
+**"Service not found" error:**
+- Run `janee list` to see configured services
+- Service names are case-sensitive
+
+**Connection timeout:**
+- Verify the database is accessible from your machine
+- Check firewall rules allow the connection
+- Try the connection string directly with `psql` or `mysql` first
+
+**Agent can't modify data:**
+- Check if you configured a read-only user (this is good!)
+- If writes are needed, create a separate service with write permissions
+
+---
+
+## Next Steps
+
+- [Janee Quickstart](./quickstart.md)
+- [Secrets Management Best Practices](./mcp-secrets-guide.md)
+- [GitHub MCP Integration](./integration-github-mcp.md)
+- [Slack MCP Integration](./integration-slack-mcp.md)

--- a/docs/multi-agent-setup.md
+++ b/docs/multi-agent-setup.md
@@ -1,0 +1,91 @@
+# Multi-Agent Setup with Janee
+
+How to use Janee across multiple AI agents simultaneously — with one set of keys and centralized audit logging.
+
+## The Problem
+
+Most developers use 2-3 AI tools daily. Each one needs API access configured separately:
+
+| Without Janee | With Janee |
+|---|---|
+| Copy keys to Claude Desktop config | Store keys once in Janee |
+| Copy keys to Cursor config | Point Claude at Janee |
+| Copy keys to Windsurf config | Point Cursor at Janee |
+| Copy keys to CLI tools | Point Windsurf at Janee |
+| Keys in 4 plaintext files | Keys in 1 encrypted vault |
+| 0 audit trail | Full audit trail |
+| Key rotation = update 4 files | Key rotation = update 1 place |
+
+## Setup
+
+### 1. Install and configure Janee once
+
+```bash
+npm install -g @true-and-useful/janee
+janee init
+janee add github --auth bearer --key ghp_xxx
+janee add stripe --auth bearer --key sk_live_xxx
+janee add openai --auth bearer --key sk-xxx
+```
+
+### 2. Add to Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json`:
+```json
+{
+  "mcpServers": {
+    "janee": { "command": "janee", "args": ["serve"] }
+  }
+}
+```
+
+### 3. Add to Cursor
+
+`.cursor/mcp.json` in your project root:
+```json
+{
+  "mcpServers": {
+    "janee": { "command": "janee", "args": ["serve"] }
+  }
+}
+```
+
+### 4. Add to any MCP client
+
+The pattern is always the same — just tell the client to run `janee serve` as an MCP server.
+
+## Audit Across Agents
+
+When multiple agents use Janee, the audit log captures which client made each request:
+
+```bash
+$ janee audit --last 5
+2026-02-12 14:23:01  claude-desktop  github    GET /user/repos
+2026-02-12 14:23:15  cursor          openai    POST /v1/chat/completions  
+2026-02-12 14:24:02  claude-desktop  stripe    GET /v1/customers
+2026-02-12 14:25:11  cursor          github    POST /repos/user/repo/issues
+2026-02-12 14:26:00  windsurf        github    GET /user/notifications
+```
+
+## Key Rotation
+
+Rotate a key once, every agent gets the update:
+
+```bash
+janee update github --key ghp_newtoken
+# Done. All agents use the new key on their next request.
+```
+
+## Access Control (Coming Soon)
+
+Future versions will support per-agent permissions:
+
+```yaml
+# ~/.janee/policies.yaml
+agents:
+  cursor:
+    allow: [github, openai]
+    deny: [stripe]  # Cursor doesn't need payment access
+  claude-desktop:
+    allow: [github, stripe, openai]
+```


### PR DESCRIPTION
Combines PRs #58 and #59 per review feedback:

- Moved all guides to `docs/` (no `examples/` subfolder)
- Combined into a single PR

**Files added:**
- `docs/claude-desktop-quickstart.md` — Step-by-step Claude Desktop setup
- `docs/multi-agent-setup.md` — Running Janee across multiple AI agents
- `docs/integration-databases-mcp.md` — Postgres, Supabase, MySQL integration

Supersedes #58 and #59.