### PR TITLE
feat: add service health check module

### DIFF
--- a/src/core/health.test.ts
+++ b/src/core/health.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi } from 'vitest';
+import { checkServiceHealth, checkAllServicesHealth } from './health.js';
+
+describe('Health Check', () => {
+  describe('checkServiceHealth', () => {
+    it('should return healthy for reachable service', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK'
+      });
+      
+      const result = await checkServiceHealth(
+        'test-service',
+        'https://api.example.com',
+        { timeout: 5000, fetchFn: mockFetch }
+      );
+      
+      expect(result.service).toBe('test-service');
+      expect(result.healthy).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should treat 401 as healthy (service reachable, auth expected)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized'
+      });
+      
+      const result = await checkServiceHealth(
+        'auth-service',
+        'https://api.example.com',
+        { timeout: 5000, fetchFn: mockFetch }
+      );
+      
+      expect(result.healthy).toBe(true);
+      expect(result.statusCode).toBe(401);
+    });
+
+    it('should treat 403 as healthy (service reachable)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden'
+      });
+      
+      const result = await checkServiceHealth(
+        'forbidden-service',
+        'https://api.example.com',
+        { timeout: 5000, fetchFn: mockFetch }
+      );
+      
+      expect(result.healthy).toBe(true);
+      expect(result.statusCode).toBe(403);
+    });
+
+    it('should return unhealthy for 500 responses', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error'
+      });
+      
+      const result = await checkServiceHealth(
+        'broken-service',
+        'https://api.example.com',
+        { timeout: 5000, fetchFn: mockFetch }
+      );
+      
+      expect(result.healthy).toBe(false);
+      expect(result.statusCode).toBe(500);
+      expect(result.error).toContain('500');
+    });
+
+    it('should return unhealthy for network errors', async () => {
+      const mockFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+      
+      const result = await checkServiceHealth(
+        'unreachable',
+        'https://api.example.com',
+        { timeout: 5000, fetchFn: mockFetch }
+      );
+      
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain('ECONNREFUSED');
+      expect(result.statusCode).toBeUndefined();
+    });
+
+    it('should return unhealthy for timeout', async () => {
+      const mockFetch = vi.fn().mockImplementation(() => 
+        new Promise((_, reject) => setTimeout(() => reject(new Error('AbortError: timeout')), 100))
+      );
+      
+      const result = await checkServiceHealth(
+        'slow-service',
+        'https://api.example.com',
+        { timeout: 50, fetchFn: mockFetch }
+      );
+      
+      expect(result.healthy).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should measure latency', async () => {
+      const mockFetch = vi.fn().mockImplementation(() =>
+        new Promise(resolve => setTimeout(() => resolve({ ok: true, status: 200, statusText: 'OK' }), 50))
+      );
+      
+      const result = await checkServiceHealth(
+        'test-service',
+        'https://api.example.com',
+        { timeout: 5000, fetchFn: mockFetch }
+      );
+      
+      expect(result.latencyMs).toBeGreaterThanOrEqual(40);
+    });
+
+    it('should handle empty baseUrl', async () => {
+      const result = await checkServiceHealth(
+        'bad-config',
+        '',
+        { timeout: 5000 }
+      );
+      
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain('No base URL configured');
+    });
+
+    it('should include timestamp', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK'
+      });
+      
+      const before = new Date().toISOString();
+      const result = await checkServiceHealth(
+        'test',
+        'https://api.example.com',
+        { timeout: 5000, fetchFn: mockFetch }
+      );
+      const after = new Date().toISOString();
+      
+      expect(result.checkedAt).toBeDefined();
+      expect(result.checkedAt >= before).toBe(true);
+      expect(result.checkedAt <= after).toBe(true);
+    });
+  });
+
+  describe('checkAllServicesHealth', () => {
+    it('should check multiple services in parallel', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK'
+      });
+
+      const services = new Map([
+        ['stripe', { baseUrl: 'https://api.stripe.com' }],
+        ['github', { baseUrl: 'https://api.github.com' }],
+      ]);
+
+      const results = await checkAllServicesHealth(services, { fetchFn: mockFetch });
+      
+      expect(results).toHaveLength(2);
+      expect(results[0].service).toBe('stripe');
+      expect(results[1].service).toBe('github');
+      expect(results.every(r => r.healthy)).toBe(true);
+    });
+
+    it('should handle mixed healthy/unhealthy services', async () => {
+      let callCount = 0;
+      const mockFetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({ ok: true, status: 200, statusText: 'OK' });
+        }
+        return Promise.reject(new Error('ECONNREFUSED'));
+      });
+
+      const services = new Map([
+        ['healthy', { baseUrl: 'https://api.good.com' }],
+        ['unhealthy', { baseUrl: 'https://api.bad.com' }],
+      ]);
+
+      const results = await checkAllServicesHealth(services, { fetchFn: mockFetch });
+      
+      expect(results[0].healthy).toBe(true);
+      expect(results[1].healthy).toBe(false);
+    });
+  });
+});

--- a/src/core/health.ts
+++ b/src/core/health.ts
@@ -1,0 +1,101 @@
+/**
+ * Health check module for Janee services
+ * Provides connectivity and latency checks for configured API backends
+ */
+
+export interface HealthCheckResult {
+  service: string;
+  healthy: boolean;
+  statusCode?: number;
+  latencyMs: number;
+  error?: string;
+  checkedAt: string;
+}
+
+export interface HealthCheckOptions {
+  timeout?: number;
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Check if a service endpoint is reachable and responding
+ */
+export async function checkServiceHealth(
+  serviceName: string,
+  baseUrl: string,
+  options: HealthCheckOptions = {}
+): Promise<HealthCheckResult> {
+  const { timeout = 5000, fetchFn = fetch } = options;
+  const checkedAt = new Date().toISOString();
+
+  if (!baseUrl) {
+    return {
+      service: serviceName,
+      healthy: false,
+      latencyMs: 0,
+      error: 'No base URL configured',
+      checkedAt
+    };
+  }
+
+  const start = Date.now();
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    const response = await fetchFn(baseUrl, {
+      method: 'HEAD',
+      signal: controller.signal
+    });
+
+    clearTimeout(timeoutId);
+    const latencyMs = Date.now() - start;
+
+    // 2xx = healthy, 401/403 = reachable (auth expected), 4xx = unhealthy, 5xx = unhealthy
+    const isReachable = response.ok || response.status === 401 || response.status === 403;
+    
+    if (isReachable) {
+      return {
+        service: serviceName,
+        healthy: true,
+        statusCode: response.status,
+        latencyMs,
+        checkedAt
+      };
+    }
+
+    return {
+      service: serviceName,
+      healthy: false,
+      statusCode: response.status,
+      latencyMs,
+      error: `HTTP ${response.status} ${response.statusText}`,
+      checkedAt
+    };
+  } catch (err) {
+    const latencyMs = Date.now() - start;
+    const message = err instanceof Error ? err.message : String(err);
+
+    return {
+      service: serviceName,
+      healthy: false,
+      latencyMs,
+      error: message,
+      checkedAt
+    };
+  }
+}
+
+/**
+ * Check health of multiple services in parallel
+ */
+export async function checkAllServicesHealth(
+  services: Map<string, { baseUrl: string }>,
+  options: HealthCheckOptions = {}
+): Promise<HealthCheckResult[]> {
+  const checks = Array.from(services.entries()).map(([name, config]) =>
+    checkServiceHealth(name, config.baseUrl, options)
+  );
+  return Promise.all(checks);
+}


### PR DESCRIPTION
## What

Adds a health check module (`src/core/health.ts`) that lets agents verify API backend connectivity before attempting requests.

## Why

When an agent tries to use Janee and gets connection errors, there's currently no way to diagnose whether the issue is:
- Service unreachable (network/DNS)
- Service down (500)
- Auth misconfigured (expected - 401/403 means service is actually reachable)

This module provides `checkServiceHealth()` and `checkAllServicesHealth()` functions that can be wired into the MCP server as a `check_health` tool, or used by the CLI for a `janee status` command.

## Design decisions

- **HEAD requests** — minimal overhead, no body transfer
- **401/403 = healthy** — these mean the service is reachable; auth rejection is expected for unauthenticated health probes
- **Configurable timeout** — defaults to 5s
- **Injectable fetch** — `fetchFn` option makes testing clean without mocking globals
- **Parallel checks** — `checkAllServicesHealth()` runs all checks concurrently

## Tests

11 new tests covering:
- Healthy responses (200, 401, 403)
- Unhealthy responses (500)
- Network errors (ECONNREFUSED)
- Timeouts
- Latency measurement
- Empty baseUrl handling
- Timestamp accuracy
- Multi-service parallel checks
- Mixed healthy/unhealthy results

All 158 tests pass (147 existing + 11 new).