### PR TITLE
Add examples directory with real-world config templates

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,92 @@
+# Janee Examples
+
+Real-world configuration examples for common use cases.
+
+## Quick Start
+
+```bash
+# Install Janee
+npm install -g @true-and-useful/janee
+
+# Initialize (generates master key)
+janee init
+
+# Copy an example config
+cp examples/claude-desktop-github-openai.yaml ~/.janee/config.yaml
+
+# Add your actual API keys
+janee add github --auth bearer --key ghp_yourtoken
+janee add openai --auth bearer --key sk-yourkey
+
+# Start serving
+janee serve
+```
+
+## Examples
+
+### [`claude-desktop-github-openai.yaml`](./claude-desktop-github-openai.yaml)
+
+**Use case:** Claude Desktop accessing GitHub and OpenAI APIs.
+
+- Read/write GitHub issues with approval
+- Use OpenAI completions and embeddings (auto-approved)
+- Blocks destructive operations (DELETE, settings changes)
+- Includes Claude Desktop JSON config snippet
+
+### [`crypto-trading-agent.yaml`](./crypto-trading-agent.yaml)
+
+**Use case:** AI agent monitoring crypto exchanges (MEXC, Bybit).
+
+- HMAC request signing — agent never sees API secrets
+- Read market data auto-approved, trades require manual approval
+- Batch orders blocked as safety measure
+- Full request body logging for trade audit
+
+### [`slack-notion-productivity.yaml`](./slack-notion-productivity.yaml)
+
+**Use case:** Productivity agent managing Slack and Notion.
+
+- Read Slack messages and Notion pages (auto-approved)
+- Send Slack messages and edit Notion (requires approval + reason)
+- Destructive operations (delete, archive) always blocked
+
+## Key Concepts
+
+**Services** define your API connections — base URL + authentication.
+
+**Capabilities** define what an agent can do — which service, what endpoints, how long, whether it needs approval.
+
+**Rules** use glob patterns to allow/deny specific HTTP methods and paths:
+```yaml
+rules:
+  allow:
+    - "GET /repos/**"      # Read any repo
+    - "POST /repos/*/issues"  # Create issues
+  deny:
+    - "DELETE /**"          # Never delete anything
+```
+
+**TTL** (time-to-live) limits how long a capability stays active:
+- `"2m"` — 2 minutes (good for writes)
+- `"10m"` — 10 minutes (good for reads)
+- `"1h"` — 1 hour (use sparingly)
+
+## Auth Types
+
+| Type | Use case | Example |
+|------|----------|---------|
+| `bearer` | Most REST APIs | GitHub, OpenAI, Slack, Notion |
+| `hmac-mexc` | MEXC exchange | Signed requests with API key + secret |
+| `hmac-bybit` | Bybit exchange | Signed requests with API key + secret |
+| `hmac-okx` | OKX exchange | Signed requests with key + secret + passphrase |
+| `headers` | Custom header auth | APIs with non-standard auth headers |
+| `service-account` | Google Cloud | Service account JSON credentials |
+
+## Security Notes
+
+- Keys are encrypted at rest with your master key
+- Never commit `~/.janee/config.yaml` with real keys to git
+- Use `autoApprove: false` for any write operations
+- Set `requiresReason: true` for sensitive operations
+- Keep TTLs as short as practical
+- Use deny rules to block destructive endpoints even if allow rules are broad

--- a/examples/claude-desktop-github-openai.yaml
+++ b/examples/claude-desktop-github-openai.yaml
@@ -1,0 +1,83 @@
+# Janee Example: Claude Desktop with GitHub + OpenAI
+#
+# This config lets Claude Desktop access GitHub and OpenAI APIs
+# through Janee, without exposing raw API keys in your Claude config.
+#
+# Setup:
+#   1. npm install -g @true-and-useful/janee
+#   2. Copy this file to ~/.janee/config.yaml
+#   3. Replace the encrypted key placeholders with your actual keys:
+#      janee add github --auth bearer --key ghp_yourtoken
+#      janee add openai --auth bearer --key sk-yourkey
+#   4. Add Janee to claude_desktop_config.json (see below)
+#   5. Restart Claude Desktop
+
+version: "1"
+masterKey: "generate-with-janee-init"
+
+server:
+  port: 3456
+  host: "127.0.0.1"
+  logBodies: false  # Don't log request bodies (privacy)
+
+services:
+  github:
+    baseUrl: "https://api.github.com"
+    auth:
+      type: bearer
+      key: "encrypted:your-github-token"
+
+  openai:
+    baseUrl: "https://api.openai.com"
+    auth:
+      type: bearer
+      key: "encrypted:your-openai-key"
+
+capabilities:
+  read-github:
+    service: github
+    ttl: "10m"
+    autoApprove: false
+    rules:
+      allow:
+        - "GET /repos/**"
+        - "GET /users/**"
+        - "GET /search/**"
+      deny:
+        - "DELETE /**"
+
+  write-github:
+    service: github
+    ttl: "5m"
+    requiresReason: true
+    rules:
+      allow:
+        - "POST /repos/*/issues"
+        - "POST /repos/*/issues/*/comments"
+        - "PATCH /repos/*/issues/*"
+      deny:
+        - "DELETE /**"
+        - "PUT /repos/*/settings"
+
+  use-openai:
+    service: openai
+    ttl: "15m"
+    autoApprove: true
+    rules:
+      allow:
+        - "POST /v1/chat/completions"
+        - "POST /v1/embeddings"
+      deny:
+        - "DELETE /**"
+        - "POST /v1/fine_tuning/**"
+
+# Claude Desktop config (add to claude_desktop_config.json):
+#
+# {
+#   "mcpServers": {
+#     "janee": {
+#       "command": "janee",
+#       "args": ["serve"]
+#     }
+#   }
+# }

--- a/examples/crypto-trading-agent.yaml
+++ b/examples/crypto-trading-agent.yaml
@@ -1,0 +1,76 @@
+# Janee Example: Crypto Trading Agent
+#
+# Secure configuration for an AI agent that monitors crypto exchanges.
+# Uses HMAC authentication for exchange APIs — Janee signs requests
+# so the agent never sees your API secret.
+#
+# Setup:
+#   1. npm install -g @true-and-useful/janee
+#   2. Copy to ~/.janee/config.yaml
+#   3. Add your exchange keys:
+#      janee add mexc --auth hmac-mexc --key YOUR_KEY --secret YOUR_SECRET
+#      janee add bybit --auth hmac-bybit --key YOUR_KEY --secret YOUR_SECRET
+#   4. Run: janee serve
+
+version: "1"
+masterKey: "generate-with-janee-init"
+
+server:
+  port: 3456
+  host: "127.0.0.1"
+  logBodies: true  # Log bodies for trade audit
+
+services:
+  mexc:
+    baseUrl: "https://api.mexc.com"
+    auth:
+      type: hmac-mexc
+      apiKey: "encrypted:your-mexc-api-key"
+      apiSecret: "encrypted:your-mexc-api-secret"
+
+  bybit:
+    baseUrl: "https://api.bybit.com"
+    auth:
+      type: hmac-bybit
+      apiKey: "encrypted:your-bybit-api-key"
+      apiSecret: "encrypted:your-bybit-api-secret"
+
+capabilities:
+  read-mexc:
+    service: mexc
+    ttl: "5m"
+    autoApprove: true
+    rules:
+      allow:
+        - "GET /api/v3/ticker/**"
+        - "GET /api/v3/depth"
+        - "GET /api/v3/klines"
+        - "GET /api/v3/account"
+      deny:
+        - "POST /**"
+        - "DELETE /**"
+
+  trade-mexc:
+    service: mexc
+    ttl: "2m"
+    autoApprove: false
+    requiresReason: true
+    rules:
+      allow:
+        - "POST /api/v3/order"
+      deny:
+        - "POST /api/v3/order/batch"
+        - "DELETE /**"
+
+  read-bybit:
+    service: bybit
+    ttl: "5m"
+    autoApprove: true
+    rules:
+      allow:
+        - "GET /v5/market/**"
+        - "GET /v5/account/**"
+        - "GET /v5/position/**"
+      deny:
+        - "POST /**"
+        - "DELETE /**"

--- a/examples/slack-notion-productivity.yaml
+++ b/examples/slack-notion-productivity.yaml
@@ -1,0 +1,87 @@
+# Janee Example: Slack + Notion for Productivity Agent
+#
+# Let your AI agent manage Slack messages and Notion pages
+# with scoped, time-limited access.
+#
+# Setup:
+#   1. npm install -g @true-and-useful/janee
+#   2. Copy to ~/.janee/config.yaml
+#   3. Add your keys:
+#      janee add slack --auth bearer --key xoxb-your-slack-bot-token
+#      janee add notion --auth bearer --key secret_your-notion-key
+#   4. Run: janee serve
+
+version: "1"
+masterKey: "generate-with-janee-init"
+
+server:
+  port: 3456
+  host: "127.0.0.1"
+  logBodies: false
+
+services:
+  slack:
+    baseUrl: "https://slack.com/api"
+    auth:
+      type: bearer
+      key: "encrypted:your-slack-bot-token"
+
+  notion:
+    baseUrl: "https://api.notion.com"
+    auth:
+      type: bearer
+      key: "encrypted:your-notion-key"
+
+capabilities:
+  read-slack:
+    service: slack
+    ttl: "10m"
+    autoApprove: true
+    rules:
+      allow:
+        - "POST /conversations.history"
+        - "POST /conversations.list"
+        - "POST /users.list"
+        - "POST /search.messages"
+      deny:
+        - "POST /chat.delete"
+        - "POST /conversations.archive"
+
+  send-slack:
+    service: slack
+    ttl: "3m"
+    autoApprove: false
+    requiresReason: true
+    rules:
+      allow:
+        - "POST /chat.postMessage"
+        - "POST /reactions.add"
+      deny:
+        - "POST /chat.delete"
+        - "POST /conversations.archive"
+
+  read-notion:
+    service: notion
+    ttl: "10m"
+    autoApprove: true
+    rules:
+      allow:
+        - "POST /v1/search"
+        - "GET /v1/pages/**"
+        - "GET /v1/blocks/**"
+        - "POST /v1/databases/*/query"
+      deny:
+        - "DELETE /**"
+        - "PATCH /v1/pages/**"
+
+  write-notion:
+    service: notion
+    ttl: "5m"
+    autoApprove: false
+    rules:
+      allow:
+        - "POST /v1/pages"
+        - "PATCH /v1/pages/**"
+        - "PATCH /v1/blocks/**"
+      deny:
+        - "DELETE /**"


### PR DESCRIPTION
## What

Adds an `examples/` directory with three practical, copy-and-modify configuration files covering the most common Janee use cases.

## Examples

| File | Use Case | Auth Types |
|------|----------|------------|
| `claude-desktop-github-openai.yaml` | Claude Desktop + GitHub/OpenAI | Bearer |
| `crypto-trading-agent.yaml` | MEXC + Bybit trading agent | HMAC |
| `slack-notion-productivity.yaml` | Slack + Notion productivity agent | Bearer |

Each config includes:
- Complete, working YAML with all required fields
- Inline comments explaining every section
- Setup instructions specific to that use case
- Security-conscious defaults (short TTLs, deny rules, approval gates)

## Why

The docs explain concepts well, but there was no "just copy this and go" starting point. These examples reduce time-to-first-use for new users.

The `examples/README.md` also serves as a quick reference for auth types, capability patterns, and security best practices.

## Files

- `examples/README.md` — overview + quick start + auth type reference
- `examples/claude-desktop-github-openai.yaml` — most common setup
- `examples/crypto-trading-agent.yaml` — HMAC signing use case
- `examples/slack-notion-productivity.yaml` — SaaS integration pattern