### PR TITLE
chore: bump version to 0.8.2 for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@true-and-useful/janee",
   "mcpName": "io.github.rsdouglas/janee",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Secrets management for AI agents via MCP",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Fixes #70

npm 0.8.1 was published before the exec mode merge (PR #69), so the `janee_exec` tool is missing from the published package.

This bumps the version to 0.8.2 so you can `npm publish` from main and users get the exec mode feature.

**After merging:** `npm publish --access public` from the repo root.