### PR TITLE
fix: add User-Agent header to proxy requests

### DIFF
--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -456,7 +456,10 @@ export function makeAPIRequest(
       port: targetUrl.port,
       path: targetUrl.pathname + targetUrl.search,
       method: request.method,
-      headers: request.headers
+      headers: {
+        'User-Agent': 'janee/' + (process.env.npm_package_version || '0.8.2'),
+        ...request.headers
+      }
     };
 
     const req = client.request(options, (res) => {


### PR DESCRIPTION
## Dogfooding Finding

While actually using janee to proxy GitHub API requests, I got a 403:

```
Request forbidden by administrative rules. Please make sure your request 
has a User-Agent header.
```

**Root cause:** `makeAPIRequest()` forwards caller-provided headers but never sets a `User-Agent`. GitHub (and many other APIs) require this header.

**Fix:** Add `'User-Agent': 'janee/<version>'` as a default header in `makeAPIRequest()`. Caller-provided headers can still override it via spread.

**Verified:**
- Before: `execute({capability: 'github', method: 'GET', path: '/user'})` → 403
- After: same call → 200, returns user profile
- All 187 existing tests pass