### PR TITLE
test: add comprehensive tests for crypto and sessions modules

### DIFF
--- a/src/core/crypto.test.ts
+++ b/src/core/crypto.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateMasterKey,
+  encryptSecret,
+  decryptSecret,
+  hashString,
+  generateToken
+} from './crypto';
+
+describe('Crypto', () => {
+  describe('generateMasterKey', () => {
+    it('should generate a base64-encoded 32-byte key', () => {
+      const key = generateMasterKey();
+      const decoded = Buffer.from(key, 'base64');
+      expect(decoded.length).toBe(32);
+    });
+
+    it('should generate unique keys each time', () => {
+      const key1 = generateMasterKey();
+      const key2 = generateMasterKey();
+      expect(key1).not.toBe(key2);
+    });
+  });
+
+  describe('encryptSecret / decryptSecret', () => {
+    it('should encrypt and decrypt a simple string', () => {
+      const key = generateMasterKey();
+      const plaintext = 'my-secret-api-key';
+      const encrypted = encryptSecret(plaintext, key);
+      const decrypted = decryptSecret(encrypted, key);
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should encrypt and decrypt an empty string', () => {
+      const key = generateMasterKey();
+      const encrypted = encryptSecret('', key);
+      const decrypted = decryptSecret(encrypted, key);
+      expect(decrypted).toBe('');
+    });
+
+    it('should encrypt and decrypt unicode text', () => {
+      const key = generateMasterKey();
+      const plaintext = '🔐 secret with émojis and ñ characters 日本語';
+      const encrypted = encryptSecret(plaintext, key);
+      const decrypted = decryptSecret(encrypted, key);
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should encrypt and decrypt long text', () => {
+      const key = generateMasterKey();
+      const plaintext = 'a'.repeat(10000);
+      const encrypted = encryptSecret(plaintext, key);
+      const decrypted = decryptSecret(encrypted, key);
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should produce different ciphertexts for the same plaintext (random IV)', () => {
+      const key = generateMasterKey();
+      const plaintext = 'same-secret';
+      const encrypted1 = encryptSecret(plaintext, key);
+      const encrypted2 = encryptSecret(plaintext, key);
+      expect(encrypted1).not.toBe(encrypted2);
+      // But both should decrypt to same value
+      expect(decryptSecret(encrypted1, key)).toBe(plaintext);
+      expect(decryptSecret(encrypted2, key)).toBe(plaintext);
+    });
+
+    it('should fail to decrypt with wrong key', () => {
+      const key1 = generateMasterKey();
+      const key2 = generateMasterKey();
+      const encrypted = encryptSecret('secret', key1);
+      expect(() => decryptSecret(encrypted, key2)).toThrow();
+    });
+
+    it('should fail with tampered ciphertext', () => {
+      const key = generateMasterKey();
+      const encrypted = encryptSecret('secret', key);
+      // Flip a character in the middle of the ciphertext
+      const buf = Buffer.from(encrypted, 'base64');
+      buf[buf.length - 1] ^= 0xff;
+      const tampered = buf.toString('base64');
+      expect(() => decryptSecret(tampered, key)).toThrow();
+    });
+
+    it('should reject invalid master key length', () => {
+      const shortKey = Buffer.from('too-short').toString('base64');
+      expect(() => encryptSecret('secret', shortKey)).toThrow('Invalid master key length');
+      expect(() => decryptSecret('dummy', shortKey)).toThrow('Invalid master key length');
+    });
+
+    it('should handle newlines and special characters in plaintext', () => {
+      const key = generateMasterKey();
+      const plaintext = 'line1\nline2\ttab\0null\r\nwindows';
+      const encrypted = encryptSecret(plaintext, key);
+      const decrypted = decryptSecret(encrypted, key);
+      expect(decrypted).toBe(plaintext);
+    });
+  });
+
+  describe('hashString', () => {
+    it('should produce a 64-character hex SHA-256 hash', () => {
+      const hash = hashString('hello');
+      expect(hash).toHaveLength(64);
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('should be deterministic', () => {
+      expect(hashString('test')).toBe(hashString('test'));
+    });
+
+    it('should produce different hashes for different inputs', () => {
+      expect(hashString('a')).not.toBe(hashString('b'));
+    });
+
+    it('should match known SHA-256 value', () => {
+      // SHA-256 of empty string
+      expect(hashString('')).toBe(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+      );
+    });
+  });
+
+  describe('generateToken', () => {
+    it('should generate a hex token of specified length', () => {
+      const token = generateToken('', 16);
+      // 16 bytes = 32 hex chars
+      expect(token).toHaveLength(32);
+      expect(token).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('should prepend prefix with underscore', () => {
+      const token = generateToken('jnee_sess', 32);
+      expect(token).toMatch(/^jnee_sess_[0-9a-f]{64}$/);
+    });
+
+    it('should generate unique tokens', () => {
+      const t1 = generateToken('test', 32);
+      const t2 = generateToken('test', 32);
+      expect(t1).not.toBe(t2);
+    });
+
+    it('should work with no prefix', () => {
+      const token = generateToken();
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('should default to 32 bytes (64 hex chars)', () => {
+      const token = generateToken();
+      expect(token).toHaveLength(64);
+    });
+  });
+});

--- a/src/core/sessions.test.ts
+++ b/src/core/sessions.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SessionManager } from './sessions';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('SessionManager', () => {
+  let tmpDir: string;
+  let persistFile: string;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'janee-sessions-test-'));
+    persistFile = path.join(tmpDir, 'sessions.json');
+    manager = new SessionManager(persistFile);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('createSession', () => {
+    it('should create a session with correct fields', () => {
+      const session = manager.createSession('read', 'stripe', 3600);
+      expect(session.id).toMatch(/^jnee_sess_/);
+      expect(session.capability).toBe('read');
+      expect(session.service).toBe('stripe');
+      expect(session.revoked).toBe(false);
+      expect(session.createdAt).toBeInstanceOf(Date);
+      expect(session.expiresAt).toBeInstanceOf(Date);
+      expect(session.expiresAt.getTime() - session.createdAt.getTime()).toBeCloseTo(3600 * 1000, -2);
+    });
+
+    it('should accept optional agentId and reason', () => {
+      const session = manager.createSession('write', 'github', 60, {
+        agentId: 'agent-123',
+        reason: 'deploy automation'
+      });
+      expect(session.agentId).toBe('agent-123');
+      expect(session.reason).toBe('deploy automation');
+    });
+
+    it('should persist session to file', () => {
+      manager.createSession('read', 'stripe', 3600);
+      expect(fs.existsSync(persistFile)).toBe(true);
+      const data = JSON.parse(fs.readFileSync(persistFile, 'utf8'));
+      expect(data).toHaveLength(1);
+      expect(data[0].capability).toBe('read');
+    });
+
+    it('should generate unique session IDs', () => {
+      const s1 = manager.createSession('read', 'stripe', 3600);
+      const s2 = manager.createSession('read', 'stripe', 3600);
+      expect(s1.id).not.toBe(s2.id);
+    });
+  });
+
+  describe('getSession', () => {
+    it('should retrieve an active session', () => {
+      const created = manager.createSession('read', 'stripe', 3600);
+      const retrieved = manager.getSession(created.id);
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.id).toBe(created.id);
+    });
+
+    it('should return undefined for non-existent session', () => {
+      expect(manager.getSession('nonexistent')).toBeUndefined();
+    });
+
+    it('should return undefined for expired session', () => {
+      vi.useFakeTimers();
+      const session = manager.createSession('read', 'stripe', 10);
+      vi.advanceTimersByTime(11000); // 11 seconds
+      const retrieved = manager.getSession(session.id);
+      expect(retrieved).toBeUndefined();
+      vi.useRealTimers();
+    });
+  });
+
+  describe('revokeSession', () => {
+    it('should revoke an active session', () => {
+      const session = manager.createSession('read', 'stripe', 3600);
+      const result = manager.revokeSession(session.id);
+      expect(result).toBe(true);
+      expect(manager.getSession(session.id)).toBeUndefined();
+    });
+
+    it('should return false for non-existent session', () => {
+      expect(manager.revokeSession('nonexistent')).toBe(false);
+    });
+
+    it('should persist revocation', () => {
+      const session = manager.createSession('read', 'stripe', 3600);
+      manager.revokeSession(session.id);
+      // Load from file — should be empty since revoked sessions are deleted
+      const data = JSON.parse(fs.readFileSync(persistFile, 'utf8'));
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  describe('listSessions', () => {
+    it('should list all active sessions', () => {
+      manager.createSession('read', 'stripe', 3600);
+      manager.createSession('write', 'github', 3600);
+      const sessions = manager.listSessions();
+      expect(sessions).toHaveLength(2);
+    });
+
+    it('should exclude expired sessions', () => {
+      vi.useFakeTimers();
+      manager.createSession('read', 'stripe', 5);
+      manager.createSession('write', 'github', 3600);
+      vi.advanceTimersByTime(6000);
+      const sessions = manager.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].capability).toBe('write');
+      vi.useRealTimers();
+    });
+
+    it('should return empty array when no sessions exist', () => {
+      expect(manager.listSessions()).toHaveLength(0);
+    });
+  });
+
+  describe('persistence', () => {
+    it('should load sessions from file on construction', () => {
+      // Create a session and save
+      manager.createSession('read', 'stripe', 3600);
+      
+      // Create new manager pointing at same file
+      const manager2 = new SessionManager(persistFile);
+      const sessions = manager2.listSessions();
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].capability).toBe('read');
+    });
+
+    it('should handle corrupt persist file gracefully', () => {
+      fs.writeFileSync(persistFile, 'not-json!!!');
+      // Should not throw
+      const mgr = new SessionManager(persistFile);
+      expect(mgr.listSessions()).toHaveLength(0);
+    });
+
+    it('should create persist directory if it does not exist', () => {
+      const deepPath = path.join(tmpDir, 'a', 'b', 'c', 'sessions.json');
+      const mgr = new SessionManager(deepPath);
+      mgr.createSession('read', 'stripe', 3600);
+      expect(fs.existsSync(deepPath)).toBe(true);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should remove expired sessions', () => {
+      vi.useFakeTimers();
+      manager.createSession('read', 'stripe', 5);
+      manager.createSession('write', 'github', 3600);
+      vi.advanceTimersByTime(6000);
+      manager.cleanup();
+      // Only the github session should remain in memory
+      const sessions = manager.listSessions();
+      expect(sessions).toHaveLength(1);
+      vi.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for two previously untested core modules:

- **`crypto.ts`** — 20 tests covering encrypt/decrypt roundtrips, empty strings, unicode, long text, random IV uniqueness, wrong-key rejection, tamper detection, key length validation, SHA-256 hashing, and token generation.
- **`sessions.ts`** — 17 tests covering session creation, retrieval, expiry, revocation, listing, persistence to disk, corrupt file recovery, directory auto-creation, and cleanup.

Increases total test count from 187 → 224.

### Why

Both `crypto.ts` and `sessions.ts` are security-critical modules (encryption and session management) that had zero test coverage. This closes that gap.

## PR Checklist

- [x] **Tests** — This PR *is* tests.
- [ ] **CHANGELOG.md** — Not user-facing (test-only change).
- [ ] **Version bump** — Not needed (test-only change).

### When Applicable

- [ ] **README.md** — N/A
- [ ] **SKILL.md** — N/A
- [ ] **docs/** — N/A
- [ ] **RFC status** — N/A
- [x] **Types** — No type changes needed
- [ ] **Security review** — N/A

### Before Merge

- [x] All tests pass (`npm test`) — 224/224 passing
- [x] Build succeeds (`npm run build`)
- [x] PR description explains *what* and *why*
- [ ] Breaking changes are clearly noted — N/A
