### PR TITLE
test: add 27 CLI command tests (list, remove, search, sessions, revoke)

### DIFF
--- a/src/cli/commands/cli-commands.test.ts
+++ b/src/cli/commands/cli-commands.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock config-yaml module
+vi.mock('../config-yaml', () => ({
+  loadYAMLConfig: vi.fn(),
+  hasYAMLConfig: vi.fn(),
+  saveYAMLConfig: vi.fn(),
+  getConfigDir: vi.fn(() => '/tmp/janee-test'),
+  getAuditDir: vi.fn(() => '/tmp/janee-test/logs'),
+}));
+
+import { loadYAMLConfig, hasYAMLConfig, saveYAMLConfig, getConfigDir } from '../config-yaml';
+import { listCommand } from './list';
+import { removeCommand } from './remove';
+import { searchCommand } from './search';
+
+const mockLoadYAMLConfig = vi.mocked(loadYAMLConfig);
+const mockHasYAMLConfig = vi.mocked(hasYAMLConfig);
+const mockSaveYAMLConfig = vi.mocked(saveYAMLConfig);
+
+// Capture console output
+function captureConsole() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args: any[]) => logs.push(args.join(' '));
+  console.error = (...args: any[]) => errors.push(args.join(' '));
+  return {
+    logs,
+    errors,
+    restore: () => {
+      console.log = origLog;
+      console.error = origError;
+    }
+  };
+}
+
+// Mock process.exit
+const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
+  throw new Error('process.exit called');
+}) as any);
+
+describe('listCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should exit with error when no config exists', async () => {
+    mockHasYAMLConfig.mockReturnValue(false);
+    const cap = captureConsole();
+    try {
+      await listCommand();
+    } catch (e) {
+      // process.exit throws
+    }
+    cap.restore();
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(cap.logs.join(' ')).toContain('No config found');
+  });
+
+  it('should show JSON error when no config exists with --json', async () => {
+    mockHasYAMLConfig.mockReturnValue(false);
+    const cap = captureConsole();
+    try {
+      await listCommand({ json: true });
+    } catch (e) {}
+    cap.restore();
+    expect(mockExit).toHaveBeenCalledWith(1);
+    const output = cap.logs.join(' ');
+    expect(output).toContain('error');
+  });
+
+  it('should list services in human-readable format', async () => {
+    mockHasYAMLConfig.mockReturnValue(true);
+    mockLoadYAMLConfig.mockReturnValue({
+      version: '0.2.0',
+      masterKey: 'test-key',
+      services: {
+        stripe: { baseUrl: 'https://api.stripe.com', auth: { type: 'bearer', key: 'sk_test' } },
+        github: { baseUrl: 'https://api.github.com', auth: { type: 'bearer', key: 'ghp_test' } },
+      },
+      capabilities: {
+        stripe_readonly: {
+          service: 'stripe',
+          ttl: '1h',
+          rules: { allow: ['GET *'], deny: ['POST *'] }
+        }
+      }
+    } as any);
+    const cap = captureConsole();
+    await listCommand();
+    cap.restore();
+    const output = cap.logs.join('\n');
+    expect(output).toContain('stripe');
+    expect(output).toContain('github');
+    expect(output).toContain('stripe_readonly');
+  });
+
+  it('should list services in JSON format', async () => {
+    mockHasYAMLConfig.mockReturnValue(true);
+    mockLoadYAMLConfig.mockReturnValue({
+      version: '0.2.0',
+      masterKey: 'test-key',
+      services: {
+        stripe: { baseUrl: 'https://api.stripe.com', auth: { type: 'bearer', key: 'sk_test' } },
+      },
+      capabilities: {
+        stripe_readonly: {
+          service: 'stripe',
+          ttl: '1h',
+          rules: { allow: ['GET *'], deny: [] }
+        }
+      }
+    } as any);
+    const cap = captureConsole();
+    await listCommand({ json: true });
+    cap.restore();
+    const parsed = JSON.parse(cap.logs.join(''));
+    expect(parsed.services).toHaveLength(1);
+    expect(parsed.services[0].name).toBe('stripe');
+    expect(parsed.capabilities).toHaveLength(1);
+  });
+
+  it('should show helpful message when no services configured', async () => {
+    mockHasYAMLConfig.mockReturnValue(true);
+    mockLoadYAMLConfig.mockReturnValue({
+      version: '0.2.0',
+      masterKey: 'test-key',
+      services: {},
+      capabilities: {}
+    } as any);
+    const cap = captureConsole();
+    await listCommand();
+    cap.restore();
+    const output = cap.logs.join('\n');
+    expect(output).toContain('No services configured');
+    expect(output).toContain('janee add');
+  });
+});
+
+describe('removeCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should exit with error when no config exists', async () => {
+    mockHasYAMLConfig.mockReturnValue(false);
+    const cap = captureConsole();
+    try {
+      await removeCommand('stripe', { yes: true });
+    } catch (e) {}
+    cap.restore();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('should exit with error when service not found', async () => {
+    mockHasYAMLConfig.mockReturnValue(true);
+    mockLoadYAMLConfig.mockReturnValue({
+      version: '0.2.0',
+      masterKey: 'test-key',
+      services: {},
+      capabilities: {}
+    } as any);
+    const cap = captureConsole();
+    try {
+      await removeCommand('nonexistent', { yes: true });
+    } catch (e) {}
+    cap.restore();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it('should remove service with --yes flag', async () => {
+    mockHasYAMLConfig.mockReturnValue(true);
+    const config = {
+      version: '0.2.0',
+      masterKey: 'test-key',
+      services: {
+        stripe: { baseUrl: 'https://api.stripe.com', auth: { type: 'bearer', key: 'sk_test' } },
+      },
+      capabilities: {}
+    } as any;
+    mockLoadYAMLConfig.mockReturnValue(config);
+    const cap = captureConsole();
+    await removeCommand('stripe', { yes: true });
+    cap.restore();
+    expect(mockSaveYAMLConfig).toHaveBeenCalled();
+    expect(cap.logs.join(' ')).toContain('removed successfully');
+  });
+
+  it('should remove dependent capabilities', async () => {
+    mockHasYAMLConfig.mockReturnValue(true);
+    const config = {
+      version: '0.2.0',
+      masterKey: 'test-key',
+      services: {
+        stripe: { baseUrl: 'https://api.stripe.com', auth: { type: 'bearer', key: 'sk_test' } },
+      },
+      capabilities: {
+        stripe_readonly: { service: 'stripe', ttl: '1h' },
+        stripe_write: { service: 'stripe', ttl: '30m' },
+      }
+    } as any;
+    mockLoadYAMLConfig.mockReturnValue(config);
+    const cap = captureConsole();
+    await removeCommand('stripe', { yes: true });
+    cap.restore();
+    expect(mockSaveYAMLConfig).toHaveBeenCalled();
+    const savedConfig = mockSaveYAMLConfig.mock.calls[0][0] as any;
+    expect(savedConfig.capabilities).toEqual({});
+  });
+
+  it('should output JSON on remove with --json', async () => {
+    mockHasYAMLConfig.mockReturnValue(true);
+    const config = {
+      version: '0.2.0',
+      masterKey: 'test-key',
+      services: {
+        stripe: { baseUrl: 'https://api.stripe.com', auth: { type: 'bearer', key: 'sk_test' } },
+      },
+      capabilities: {}
+    } as any;
+    mockLoadYAMLConfig.mockReturnValue(config);
+    const cap = captureConsole();
+    await removeCommand('stripe', { json: true });
+    cap.restore();
+    const parsed = JSON.parse(cap.logs.join(''));
+    expect(parsed.ok).toBe(true);
+    expect(parsed.service).toBe('stripe');
+  });
+
+  it('should output JSON error when service not found with --json', async () => {
+    mockHasYAMLConfig.mockReturnValue(true);
+    mockLoadYAMLConfig.mockReturnValue({
+      version: '0.2.0',
+      masterKey: 'test-key',
+      services: {},
+      capabilities: {}
+    } as any);
+    const cap = captureConsole();
+    try {
+      await removeCommand('nonexistent', { json: true });
+    } catch (e) {}
+    cap.restore();
+    // Find the JSON log entry
+    const jsonLog = cap.logs.find(l => l.startsWith('{'));
+    expect(jsonLog).toBeDefined();
+    const parsed = JSON.parse(jsonLog!);
+    expect(parsed.ok).toBe(false);
+  });
+});
+
+describe('searchCommand', () => {
+  it('should list all services when no query', () => {
+    const cap = captureConsole();
+    searchCommand();
+    cap.restore();
+    const output = cap.logs.join('\n');
+    expect(output).toContain('Service Directory');
+  });
+
+  it('should output JSON when --json and no query', () => {
+    const cap = captureConsole();
+    searchCommand(undefined, { json: true });
+    cap.restore();
+    const parsed = JSON.parse(cap.logs.join(''));
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+
+  it('should search for specific service', () => {
+    const cap = captureConsole();
+    searchCommand('stripe');
+    cap.restore();
+    const output = cap.logs.join('\n');
+    expect(output).toContain('stripe');
+  });
+
+  it('should handle no results gracefully', () => {
+    const cap = captureConsole();
+    searchCommand('zzz_nonexistent_service_zzz');
+    cap.restore();
+    const output = cap.logs.join('\n');
+    expect(output).toContain('No services found');
+  });
+
+  it('should output JSON search results', () => {
+    const cap = captureConsole();
+    searchCommand('stripe', { json: true });
+    cap.restore();
+    const parsed = JSON.parse(cap.logs.join(''));
+    expect(Array.isArray(parsed)).toBe(true);
+  });
+});

--- a/src/cli/commands/sessions-revoke.test.ts
+++ b/src/cli/commands/sessions-revoke.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Mock config-yaml module
+vi.mock('../config-yaml', () => ({
+  getConfigDir: vi.fn(() => '/tmp/janee-test-sessions'),
+}));
+
+import { getConfigDir } from '../config-yaml';
+import { sessionsCommand } from './sessions';
+import { revokeCommand } from './revoke';
+
+const TEST_DIR = '/tmp/janee-test-sessions';
+const SESSIONS_FILE = path.join(TEST_DIR, 'sessions.json');
+
+function captureConsole() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args: any[]) => logs.push(args.join(' '));
+  console.error = (...args: any[]) => errors.push(args.join(' '));
+  return {
+    logs,
+    errors,
+    restore: () => {
+      console.log = origLog;
+      console.error = origError;
+    }
+  };
+}
+
+const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
+  throw new Error('process.exit called');
+}) as any);
+
+function createTestSessions(sessions: any[]) {
+  if (!fs.existsSync(TEST_DIR)) {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+  }
+  fs.writeFileSync(SESSIONS_FILE, JSON.stringify(sessions, null, 2));
+}
+
+function cleanupTestDir() {
+  if (fs.existsSync(TEST_DIR)) {
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  }
+}
+
+describe('sessionsCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanupTestDir();
+  });
+
+  afterEach(() => {
+    cleanupTestDir();
+  });
+
+  it('should show no active sessions when file does not exist', async () => {
+    const cap = captureConsole();
+    await sessionsCommand();
+    cap.restore();
+    expect(cap.logs.join(' ')).toContain('No active sessions');
+  });
+
+  it('should output empty JSON array when no sessions file and --json', async () => {
+    const cap = captureConsole();
+    await sessionsCommand({ json: true });
+    cap.restore();
+    const parsed = JSON.parse(cap.logs.join(''));
+    expect(parsed.sessions).toEqual([]);
+  });
+
+  it('should show active sessions', async () => {
+    const future = new Date(Date.now() + 3600000).toISOString();
+    createTestSessions([{
+      id: 'sess-abc123def456ghi789',
+      capability: 'stripe_readonly',
+      service: 'stripe',
+      agentId: 'test-agent',
+      reason: 'testing',
+      createdAt: new Date().toISOString(),
+      expiresAt: future,
+      revoked: false,
+    }]);
+    const cap = captureConsole();
+    await sessionsCommand();
+    cap.restore();
+    const output = cap.logs.join('\n');
+    expect(output).toContain('stripe_readonly');
+    expect(output).toContain('test-agent');
+    expect(output).toContain('1 active session');
+  });
+
+  it('should filter out expired sessions', async () => {
+    const past = new Date(Date.now() - 3600000).toISOString();
+    createTestSessions([{
+      id: 'sess-expired123456789',
+      capability: 'stripe_readonly',
+      service: 'stripe',
+      createdAt: new Date().toISOString(),
+      expiresAt: past,
+      revoked: false,
+    }]);
+    const cap = captureConsole();
+    await sessionsCommand();
+    cap.restore();
+    expect(cap.logs.join(' ')).toContain('No active sessions');
+  });
+
+  it('should filter out revoked sessions', async () => {
+    const future = new Date(Date.now() + 3600000).toISOString();
+    createTestSessions([{
+      id: 'sess-revoked123456789',
+      capability: 'stripe_readonly',
+      service: 'stripe',
+      createdAt: new Date().toISOString(),
+      expiresAt: future,
+      revoked: true,
+    }]);
+    const cap = captureConsole();
+    await sessionsCommand();
+    cap.restore();
+    expect(cap.logs.join(' ')).toContain('No active sessions');
+  });
+
+  it('should output active sessions as JSON', async () => {
+    const future = new Date(Date.now() + 3600000).toISOString();
+    createTestSessions([{
+      id: 'sess-json123456789abc',
+      capability: 'github_access',
+      service: 'github',
+      agentId: 'claude',
+      reason: 'code review',
+      createdAt: new Date().toISOString(),
+      expiresAt: future,
+      revoked: false,
+    }]);
+    const cap = captureConsole();
+    await sessionsCommand({ json: true });
+    cap.restore();
+    const parsed = JSON.parse(cap.logs.join(''));
+    expect(parsed.sessions).toHaveLength(1);
+    expect(parsed.sessions[0].capability).toBe('github_access');
+    expect(parsed.sessions[0].ttlSeconds).toBeGreaterThan(0);
+  });
+
+  it('should show multiple active sessions count', async () => {
+    const future = new Date(Date.now() + 3600000).toISOString();
+    createTestSessions([
+      { id: 'sess-multi1-123456789', capability: 'stripe', service: 'stripe', createdAt: new Date().toISOString(), expiresAt: future, revoked: false },
+      { id: 'sess-multi2-123456789', capability: 'github', service: 'github', createdAt: new Date().toISOString(), expiresAt: future, revoked: false },
+      { id: 'sess-multi3-123456789', capability: 'openai', service: 'openai', createdAt: new Date().toISOString(), expiresAt: future, revoked: false },
+    ]);
+    const cap = captureConsole();
+    await sessionsCommand();
+    cap.restore();
+    expect(cap.logs.join(' ')).toContain('3 active sessions');
+  });
+});
+
+describe('revokeCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanupTestDir();
+  });
+
+  afterEach(() => {
+    cleanupTestDir();
+  });
+
+  it('should exit with error when no sessions file', async () => {
+    const cap = captureConsole();
+    try {
+      await revokeCommand('sess-abc');
+    } catch (e) {}
+    cap.restore();
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(cap.errors.join(' ')).toContain('No sessions file');
+  });
+
+  it('should exit with error when session not found', async () => {
+    createTestSessions([{
+      id: 'sess-existing123456789',
+      capability: 'stripe',
+      service: 'stripe',
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+      revoked: false,
+    }]);
+    const cap = captureConsole();
+    try {
+      await revokeCommand('sess-nonexistent');
+    } catch (e) {}
+    cap.restore();
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(cap.errors.join(' ')).toContain('Session not found');
+  });
+
+  it('should revoke session by prefix', async () => {
+    const future = new Date(Date.now() + 3600000).toISOString();
+    createTestSessions([{
+      id: 'sess-torevoke123456789',
+      capability: 'stripe_readonly',
+      service: 'stripe',
+      agentId: 'test-agent',
+      createdAt: new Date().toISOString(),
+      expiresAt: future,
+      revoked: false,
+    }]);
+    const cap = captureConsole();
+    await revokeCommand('sess-torevoke');
+    cap.restore();
+    expect(cap.logs.join(' ')).toContain('Session revoked');
+
+    // Verify the file was updated
+    const data = JSON.parse(fs.readFileSync(SESSIONS_FILE, 'utf8'));
+    expect(data[0].revoked).toBe(true);
+  });
+
+  it('should warn when session already revoked', async () => {
+    createTestSessions([{
+      id: 'sess-alreadyrevoked1234',
+      capability: 'stripe',
+      service: 'stripe',
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 3600000).toISOString(),
+      revoked: true,
+    }]);
+    const cap = captureConsole();
+    await revokeCommand('sess-alreadyrevoked');
+    cap.restore();
+    expect(cap.logs.join(' ')).toContain('already revoked');
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for the CLI commands that were previously untested.

### New test files:
- `src/cli/commands/cli-commands.test.ts` — 16 tests covering `listCommand`, `removeCommand`, and `searchCommand`
- `src/cli/commands/sessions-revoke.test.ts` — 11 tests covering `sessionsCommand` and `revokeCommand`

### What's covered:
| Command | Tests | Scenarios |
|---------|-------|-----------|
| `list` | 5 | No config, JSON error, human-readable output, JSON output, empty services |
| `remove` | 6 | No config, not found, removal with --yes, dependent capability cleanup, JSON output |
| `search` | 5 | List all, JSON output, search by query, no results, JSON search results |
| `sessions` | 7 | No file, empty JSON, active sessions, expired filtering, revoked filtering, JSON output |
| `revoke` | 4 | No file, not found, revoke by prefix, already-revoked warning |

### Results:
- **27 new tests**, all passing
- Total suite: **214 tests** (up from 187 on main)
- Zero changes to source code — tests only