### PR TITLE
docs: add exec mode examples for deploy and git operations

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,7 +50,40 @@ janee serve
 - Send Slack messages and edit Notion (requires approval + reason)
 - Destructive operations (delete, archive) always blocked
 
+
+### [`exec-mode-deploy.yaml`](./exec-mode-deploy.yaml)
+
+**Use case:** AI agent deploying code and managing infrastructure via CLI tools.
+
+- AWS CLI with read-only access (auto-approved) — credentials injected as env vars
+- Docker build & push with approval required
+- Fly.io deploy with reason required
+- All exec mode — agent runs commands but never sees raw keys
+
+### [`exec-mode-git-ops.yaml`](./exec-mode-git-ops.yaml)
+
+**Use case:** AI agent performing Git operations with managed credentials.
+
+- Read operations (clone, fetch, log) auto-approved
+- Write operations (push, tag) require approval + reason
+- Force pushes and pushes to main explicitly denied
+- Uses `GIT_ASKPASS` for transparent credential injection
+
 ## Key Concepts
+
+
+**Exec mode** runs CLI commands with credentials injected as environment variables.
+The agent specifies the command; Janee injects the secret and scrubs it from output:
+```yaml
+capabilities:
+  deploy:
+    service: fly-deploy
+    mode: exec
+    allowCommands: ["fly", "flyctl"]
+    env:
+      FLY_API_TOKEN: "{{credential}}"
+    ttl: "10m"
+```
 
 **Services** define your API connections — base URL + authentication.
 
@@ -80,6 +113,7 @@ rules:
 | `hmac-bybit` | Bybit exchange | Signed requests with API key + secret |
 | `hmac-okx` | OKX exchange | Signed requests with key + secret + passphrase |
 | `headers` | Custom header auth | APIs with non-standard auth headers |
+| `exec` | CLI tools | AWS CLI, Docker, Git, Fly.io, kubectl |
 | `service-account` | Google Cloud | Service account JSON credentials |
 
 ## Security Notes

--- a/examples/exec-mode-deploy.yaml
+++ b/examples/exec-mode-deploy.yaml
@@ -1,0 +1,117 @@
+# Janee Example: Exec Mode — Deploy & DevOps
+#
+# This config lets an AI agent deploy code, manage infrastructure,
+# and interact with cloud CLIs — without ever seeing your credentials.
+#
+# Exec mode injects secrets via environment variables into whitelisted
+# commands. The agent sees stdout/stderr but never the raw keys.
+#
+# Setup:
+#   1. npm install -g @true-and-useful/janee
+#   2. janee init
+#   3. Add your credentials:
+#      janee add aws-prod --exec --key AKIAIOSFODNN7EXAMPLE
+#      janee add docker-registry --exec --key dckr_pat_yourtoken
+#      janee add fly-deploy --exec --key fo1_yourtoken
+#   4. Copy this file to ~/.janee/config.yaml (merge with existing)
+#   5. janee serve
+
+version: "1"
+masterKey: "generate-with-janee-init"
+
+services:
+  aws-prod:
+    auth:
+      type: bearer
+      key: "encrypted:your-aws-key"
+    extraCredentials:
+      apiSecret: "encrypted:your-aws-secret"
+
+  docker-registry:
+    auth:
+      type: bearer
+      key: "encrypted:your-docker-pat"
+
+  fly-deploy:
+    auth:
+      type: bearer
+      key: "encrypted:your-fly-token"
+
+capabilities:
+  # AWS CLI — read-only access for debugging
+  aws-readonly:
+    service: aws-prod
+    mode: exec
+    allowCommands: ["aws"]
+    env:
+      AWS_ACCESS_KEY_ID: "{{apiKey}}"
+      AWS_SECRET_ACCESS_KEY: "{{apiSecret}}"
+      AWS_DEFAULT_REGION: "us-east-1"
+    ttl: "10m"
+    autoApprove: false
+    timeout: 30000
+    rules:
+      allow:
+        - "aws s3 ls *"
+        - "aws ecs describe-*"
+        - "aws logs get-*"
+      deny:
+        - "aws iam *"
+        - "aws s3 rm *"
+
+  # Docker — build and push images
+  docker-push:
+    service: docker-registry
+    mode: exec
+    allowCommands: ["docker"]
+    env:
+      DOCKER_TOKEN: "{{credential}}"
+    ttl: "15m"
+    requiresReason: true
+    timeout: 120000
+    rules:
+      allow:
+        - "docker build *"
+        - "docker push *"
+        - "docker tag *"
+      deny:
+        - "docker rm *"
+        - "docker system prune *"
+
+  # Fly.io — deploy applications
+  fly-app-deploy:
+    service: fly-deploy
+    mode: exec
+    allowCommands: ["fly", "flyctl"]
+    env:
+      FLY_API_TOKEN: "{{credential}}"
+    ttl: "10m"
+    requiresReason: true
+    timeout: 180000
+    rules:
+      allow:
+        - "fly deploy *"
+        - "fly status *"
+        - "fly logs *"
+      deny:
+        - "fly destroy *"
+        - "fly secrets *"
+
+# Agent config for Claude Desktop / Cursor:
+#
+# {
+#   "mcpServers": {
+#     "janee": {
+#       "command": "janee",
+#       "args": ["serve"]
+#     }
+#   }
+# }
+#
+# The agent can now run:
+#   janee_exec(capability="aws-readonly", command=["aws", "s3", "ls"])
+#   janee_exec(capability="docker-push", command=["docker", "build", "-t", "myapp:latest", "."])
+#   janee_exec(capability="fly-app-deploy", command=["fly", "deploy"])
+#
+# Credentials are injected as env vars — the agent never sees the raw keys.
+# All executions are audited in ~/.janee/audit.log.

--- a/examples/exec-mode-git-ops.yaml
+++ b/examples/exec-mode-git-ops.yaml
@@ -1,0 +1,70 @@
+# Janee Example: Exec Mode — Git Operations
+#
+# Let agents push code, create tags, and manage repos
+# with Git credentials injected securely via env vars.
+#
+# Setup:
+#   1. janee add github-push --exec --key ghp_yourtoken
+#   2. Merge this config into ~/.janee/config.yaml
+#   3. janee serve
+
+version: "1"
+masterKey: "generate-with-janee-init"
+
+services:
+  github-push:
+    auth:
+      type: bearer
+      key: "encrypted:your-github-pat"
+
+capabilities:
+  git-read:
+    service: github-push
+    mode: exec
+    allowCommands: ["git"]
+    env:
+      GIT_ASKPASS: "/bin/echo"
+      GIT_USERNAME: "x-access-token"
+      GIT_PASSWORD: "{{credential}}"
+    ttl: "15m"
+    autoApprove: true
+    timeout: 30000
+    rules:
+      allow:
+        - "git clone *"
+        - "git fetch *"
+        - "git log *"
+        - "git diff *"
+        - "git status"
+      deny:
+        - "git push *"
+        - "git force *"
+
+  git-write:
+    service: github-push
+    mode: exec
+    allowCommands: ["git"]
+    env:
+      GIT_ASKPASS: "/bin/echo"
+      GIT_USERNAME: "x-access-token"
+      GIT_PASSWORD: "{{credential}}"
+    ttl: "5m"
+    autoApprove: false
+    requiresReason: true
+    timeout: 60000
+    rules:
+      allow:
+        - "git push origin *"
+        - "git tag *"
+      deny:
+        - "git push --force *"
+        - "git push origin main"
+
+# Example agent interactions:
+#
+#   janee_exec(capability="git-read", command=["git", "log", "--oneline", "-10"])
+#   janee_exec(capability="git-write", command=["git", "push", "origin", "feature-branch"],
+#              reason="Pushing reviewed changes to feature branch")
+#
+# The agent authenticates via injected env vars but never sees the PAT.
+# Force pushes to main are denied by policy.


### PR DESCRIPTION
## What

Adds two new example configs demonstrating the exec mode feature from PR #88:

### `exec-mode-deploy.yaml`
- AWS CLI with read-only credentials (auto-approved)
- Docker build & push with approval required
- Fly.io deployment with reason-required policy
- Shows `apiKey`/`apiSecret` template variables for HMAC-style auth

### `exec-mode-git-ops.yaml`
- Git read operations (clone, fetch, log) — auto-approved
- Git write operations (push, tag) — manual approval + reason
- Force pushes and direct main pushes explicitly denied
- Uses `GIT_ASKPASS` for transparent credential injection

### `examples/README.md` updates
- New example descriptions in the examples index
- Exec mode explanation in Key Concepts section
- `exec` auth type added to reference table

## Why

Exec mode is janee's most unique feature — it extends secrets management beyond HTTP APIs to any CLI tool. These examples make it easy for new users to get started with real-world use cases like deployment, Docker, and Git.

## Testing

Docs-only change. YAML syntax verified.