### PR TITLE
feat: HTTP server lifecycle management with graceful shutdown and idle session cleanup

### DIFF
--- a/src/core/mcp-server-http.test.ts
+++ b/src/core/mcp-server-http.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { startMCPServerHTTP, MCPServerOptions } from './mcp-server';
+import { SessionManager } from './sessions';
+import { AuditLogger } from './audit';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+function makeOptions(): MCPServerOptions {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'janee-http-test-'));
+  return {
+    capabilities: [
+      {
+        name: 'test-cap',
+        service: 'test-svc',
+        ttl: '1h',
+        mode: 'proxy',
+      },
+    ],
+    services: new Map([
+      [
+        'test-svc',
+        {
+          url: 'https://example.com',
+          auth: { type: 'bearer' as const, key: 'test-key' },
+        },
+      ],
+    ]),
+    sessionManager: new SessionManager(),
+    auditLogger: new AuditLogger(tmpDir),
+    onExecute: async () => ({ status: 200, body: '{}' }),
+  };
+}
+
+describe('startMCPServerHTTP lifecycle', () => {
+  let handle: Awaited<ReturnType<typeof startMCPServerHTTP>> | undefined;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.close();
+      handle = undefined;
+    }
+  });
+
+  it('returns a handle with close() and sessionCount()', async () => {
+    handle = await startMCPServerHTTP(makeOptions(), {
+      host: '127.0.0.1',
+      port: 0, // let OS pick a port
+    });
+
+    expect(typeof handle.close).toBe('function');
+    expect(typeof handle.sessionCount).toBe('function');
+    expect(handle.sessionCount()).toBe(0);
+  });
+
+  it('close() shuts down the HTTP server', async () => {
+    handle = await startMCPServerHTTP(makeOptions(), {
+      host: '127.0.0.1',
+      port: 0,
+    });
+
+    await handle.close();
+    handle = undefined; // prevent double-close in afterEach
+  });
+
+  it('starts with 0 sessions', async () => {
+    handle = await startMCPServerHTTP(makeOptions(), {
+      host: '127.0.0.1',
+      port: 0,
+    });
+
+    expect(handle.sessionCount()).toBe(0);
+  });
+});

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -795,6 +795,14 @@ export async function startMCPServer(serverOptions: MCPServerOptions): Promise<v
   console.error('Janee MCP server started (stdio)');
 }
 
+/** Handle returned by startMCPServerHTTP for lifecycle management. */
+export interface HTTPServerHandle {
+  /** Gracefully close all sessions and stop the HTTP listener. */
+  close(): Promise<void>;
+  /** Number of active MCP sessions. */
+  sessionCount(): number;
+}
+
 /**
  * Start MCP server with StreamableHTTP transport over HTTP.
  *
@@ -802,17 +810,24 @@ export async function startMCPServer(serverOptions: MCPServerOptions): Promise<v
  * Each session gets its own Server instance so that concurrent clients don't
  * interfere — the SDK's Server.connect() sets a single _transport slot, so
  * sharing a Server across transports would route responses to the wrong client.
+ *
+ * Returns an HTTPServerHandle for graceful shutdown and session introspection.
+ * Sessions that are idle for longer than `idleTimeoutMs` (default: 30 minutes)
+ * are automatically closed to prevent memory leaks.
  */
 export async function startMCPServerHTTP(
   serverOptions: MCPServerOptions,
-  httpOptions: { host: string; port: number; runnerKey?: string; authorityHooks?: import('./authority.js').AuthorityExecHooks }
-): Promise<void> {
+  httpOptions: { host: string; port: number; idleTimeoutMs?: number; runnerKey?: string; authorityHooks?: import('./authority.js').AuthorityExecHooks }
+): Promise<HTTPServerHandle> {
   const app = express();
   app.use(express.json());
+
+  const idleTimeoutMs = httpOptions.idleTimeoutMs ?? 30 * 60 * 1000; // default 30 min
 
   const sessions = new Map<string, {
     transport: StreamableHTTPServerTransport;
     server: Server;
+    lastActivityAt: number;
   }>();
 
   // Authority REST endpoints -- active when runnerKey is provided
@@ -863,12 +878,34 @@ export async function startMCPServerHTTP(
     });
   }
 
+  // Sweep idle sessions every 60 seconds
+  const idleSweepInterval = idleTimeoutMs > 0 ? setInterval(async () => {
+    const now = Date.now();
+    for (const [sid, session] of sessions.entries()) {
+      if (now - session.lastActivityAt > idleTimeoutMs) {
+        console.error(`Closing idle session ${sid} (inactive for ${Math.round((now - session.lastActivityAt) / 1000)}s)`);
+        sessions.delete(sid);
+        try {
+          await session.transport.close?.();
+          await session.server.close();
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+  }, Math.min(idleTimeoutMs, 60_000)) : undefined;
+
+  if (idleSweepInterval) {
+    idleSweepInterval.unref?.(); // Don't prevent Node from exiting
+  }
+
   app.all('/mcp', async (req, res) => {
     try {
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
       if (sessionId && sessions.has(sessionId)) {
         const session = sessions.get(sessionId)!;
+        session.lastActivityAt = Date.now();
         await session.transport.handleRequest(req, res, req.body);
 
       } else if (!sessionId && isInitializeRequest(req.body)) {
@@ -878,7 +915,7 @@ export async function startMCPServerHTTP(
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => crypto.randomUUID(),
           onsessioninitialized: (sid: string) => {
-            sessions.set(sid, { transport, server });
+            sessions.set(sid, { transport, server, lastActivityAt: Date.now() });
             if (clientName) clientSessions.set(sid, clientName);
           },
           onsessionclosed: async (sid: string) => {
@@ -923,9 +960,36 @@ export async function startMCPServerHTTP(
   });
 
   return new Promise((resolve) => {
-    app.listen(httpOptions.port, httpOptions.host, () => {
+    const httpServer = app.listen(httpOptions.port, httpOptions.host, () => {
       console.error(`Janee MCP server listening on http://${httpOptions.host}:${httpOptions.port}/mcp (StreamableHTTP)`);
-      resolve();
+
+      const handle: HTTPServerHandle = {
+        async close() {
+          if (idleSweepInterval) clearInterval(idleSweepInterval);
+
+          // Close all active sessions
+          const closeTasks = Array.from(sessions.entries()).map(async ([sid, session]) => {
+            sessions.delete(sid);
+            try {
+              await session.transport.close?.();
+              await session.server.close();
+            } catch {
+              // best-effort
+            }
+          });
+          await Promise.all(closeTasks);
+
+          // Close the HTTP listener
+          await new Promise<void>((resolveClose, rejectClose) => {
+            httpServer.close((err) => err ? rejectClose(err) : resolveClose());
+          });
+        },
+        sessionCount() {
+          return sessions.size;
+        },
+      };
+
+      resolve(handle);
     });
   });
 }


### PR DESCRIPTION
## Summary

Now that multi-session HTTP transport landed in #99, this PR adds lifecycle management for the HTTP server — graceful shutdown and automatic idle session cleanup.

## Changes

- `startMCPServerHTTP` now returns an `HTTPServerHandle` with:
  - `close()` — gracefully closes all active MCP sessions, then stops the HTTP listener
  - `sessionCount()` — returns the number of active sessions (useful for monitoring)
- **Idle session timeout**: Sessions that have no activity for `idleTimeoutMs` (default: 30 minutes) are automatically closed. This prevents memory leaks from abandoned agent connections.
- Each session tracks `lastActivityAt`, updated on every request
- Idle sweep runs every 60 seconds (or less if timeout is shorter), with `unref()` so it does not prevent Node.js from exiting
- Added `mcp-server-http.test.ts` with tests for the new lifecycle API

## Why

With HTTP transport, agents can disconnect without sending a proper close — the server has no way to know. Without idle timeout, abandoned sessions accumulate indefinitely. The graceful shutdown handle also makes it straightforward to stop the server in integration tests and deployment scripts.

## Testing

- All 343 tests pass (340 existing + 3 new)
- `npx tsc --noEmit` clean
- Backward compatible: existing callers that ignore the return value continue to work