### PR TITLE
chore: update server.json to v0.10.1 and expand npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,15 @@
     "secrets",
     "mcp",
     "model-context-protocol",
-    "api-proxy"
+    "api-proxy",
+    "api-keys",
+    "credential-management",
+    "secrets-management",
+    "ai-security",
+    "claude",
+    "llm",
+    "prompt-injection",
+    "audit-log"
   ],
   "author": {
     "name": "True and Useful LLC",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,19 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.rsdouglas/janee",
-  "description": "Secure secrets proxy for AI agents — manages API keys so agents never see raw credentials.",
+  "title": "Janee — Secrets Management for AI Agents",
+  "description": "Secure secrets proxy for AI agents — manages API keys so agents never see raw credentials. Supports request policies, audit logging, session TTLs, exec mode, and GitHub App auth.",
   "repository": {
     "url": "https://github.com/rsdouglas/janee",
     "source": "github"
   },
-  "version": "0.8.5",
+  "websiteUrl": "https://janee.io",
+  "version": "0.10.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@true-and-useful/janee",
-      "version": "0.8.5",
+      "version": "0.10.1",
       "transport": {
         "type": "stdio"
       },
@@ -24,6 +26,12 @@
           "name": "JANEE_CONFIG"
         }
       ]
+    }
+  ],
+  "remotes": [
+    {
+      "transportType": "http",
+      "url": "http://localhost:9100/mcp"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two small discoverability improvements:

### server.json updates
- **Version bump**: 0.8.5 → 0.10.1 to match published npm package
- **Added `title`**: "Janee — Secrets Management for AI Agents"
- **Expanded `description`**: includes request policies, audit logging, session TTLs, exec mode, and GitHub App auth
- **Added `websiteUrl`**: https://janee.io
- **Added `remotes`**: HTTP transport endpoint at localhost:9100/mcp

The server.json was stale from a few releases back — MCP registries and tools that consume this file were seeing outdated info.

### npm keyword expansion
Added 8 new keywords to improve npm search discoverability:
- `api-keys`, `credential-management`, `secrets-management`
- `ai-security`, `claude`, `llm`
- `prompt-injection`, `audit-log`

These map to common search terms people use when looking for MCP security tools.