### PR TITLE
fix: bump server.json version to match published v0.10.1

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/rsdouglas/janee",
     "source": "github"
   },
-  "version": "0.8.5",
+  "version": "0.10.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@true-and-useful/janee",
-      "version": "0.8.5",
+      "version": "0.10.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Problem

The [MCP Registry](https://registry.modelcontextprotocol.io) reads `server.json` from the default branch to display server info. Currently `server.json` shows **v0.8.5** while the published npm package is at **v0.10.1**.

This means janee appears outdated on the official MCP Registry.

## Fix

Bumps `version` fields in `server.json` to `0.10.1` to match the currently published npm version.

## Impact

Once merged, the MCP Registry will reflect the correct version, improving discoverability and trust for users browsing the registry.