### PR TITLE
docs: document cwd, agent identity forwarding, and GIT_ASKPASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | 🏠 **Local-first** | Keys encrypted on your machine, never sent to a cloud |
 | 🖥️ **Exec mode** | Run CLI tools with injected credentials — agents never see the keys |
 | 🤖 **GitHub App auth** | Short-lived tokens for autonomous agents — no static PATs |
+| 🔧 **Automatic git auth** | `git push/pull` just works when credentials include GitHub tokens |
 
 ---
 
@@ -164,6 +165,7 @@ Now agents can run CLI tools through Janee without ever seeing the API key:
 janee_exec({
   capability: "twitter",
   command: ["bird", "post", "Hello world!"],
+  cwd: "/home/agent/project",  // optional working directory
   reason: "User asked to post a tweet"
 })
 ```
@@ -177,6 +179,31 @@ Janee spawns the process with `TWITTER_API_KEY` injected, runs the command, and 
 - `--work-dir` — working directory for the subprocess
 - `--timeout` — max execution time (default: 30s)
 
+
+### Git operations (automatic HTTPS auth)
+
+When using exec mode with GitHub credentials, Janee automatically handles git authentication. No extra configuration needed — `git push`, `git pull`, and `git clone` just work:
+
+```yaml
+capabilities:
+  - name: git-ops
+    service: github
+    mode: exec
+    allowCommands: [git]
+    env:
+      GH_TOKEN: "{{credential}}"
+```
+
+```typescript
+// Agent can push code without ever seeing the token
+janee_exec({
+  capability: "git-ops",
+  command: ["git", "push", "origin", "main"],
+  cwd: "/workspace/my-repo"
+})
+```
+
+Janee detects `git` commands with `GH_TOKEN`/`GITHUB_TOKEN` in the environment and creates a temporary askpass script for HTTPS authentication. The script is cleaned up automatically after the command completes.
 
 ### Add GitHub App auth (for autonomous agents)
 

--- a/docs/runner-authority.md
+++ b/docs/runner-authority.md
@@ -200,3 +200,54 @@ services:
 **Commands fail but worked in non-Runner mode**
 - The command runs inside the container — ensure the executable is installed there
 - Working directory may differ; set `workDir` in the capability config
+
+## Recent Features
+
+### Working Directory (`cwd`) — v0.11.2
+
+Agents can specify the working directory for exec commands using the `cwd` parameter:
+
+```json
+{
+  "tool": "janee_exec",
+  "arguments": {
+    "capability": "gh-cli",
+    "command": ["gh", "pr", "list"],
+    "cwd": "/home/agent/project"
+  }
+}
+```
+
+Without `cwd`, commands run in the Runner's `process.cwd()`. This is useful when agents work on multiple projects or need to run commands in a specific repository checkout.
+
+### Agent Identity Forwarding — v0.11.1
+
+The Runner now maintains **per-agent MCP sessions** with the Authority. Previously, the Authority saw all requests as coming from the Runner itself. Now each unique agent gets its own session, so `allowedAgents` access control works correctly through the Runner.
+
+This is transparent — agents don't need to do anything differently. The Runner reads the agent's `clientInfo.name` from the MCP initialize handshake and creates a corresponding session with the Authority.
+
+```
+Agent "creature:patch" ──▶ Runner ──▶ Authority session for "creature:patch"
+Agent "creature:voyager" ──▶ Runner ──▶ Authority session for "creature:voyager"
+```
+
+### GitHub App Token Minting in Exec — v0.11.1
+
+Capabilities using `github-app` auth type now work correctly in exec mode. The Authority mints short-lived GitHub App installation tokens and injects them as environment variables for the command.
+
+### Automatic GIT_ASKPASS — v0.11.2
+
+When `janee_exec` runs a `git` command and the capability injects `GH_TOKEN` or `GITHUB_TOKEN` as an environment variable, Janee automatically creates a temporary askpass script. This makes HTTPS authentication transparent — agents can `git push`, `git pull`, and `git clone` without any extra configuration.
+
+The askpass script is created before the command runs and cleaned up automatically afterward. It returns `x-access-token` as the username and the token value as the password, following GitHub's HTTPS token authentication protocol.
+
+```yaml
+# This "just works" — git auth is handled automatically
+capabilities:
+  - name: git-ops
+    service: github
+    mode: exec
+    allowCommands: [git]
+    env:
+      GH_TOKEN: "{{credential}}"
+```


### PR DESCRIPTION
The recent v0.11.1 and v0.11.2 features are great but not documented yet. This adds coverage for:

### README.md
- Added `cwd` parameter to the `janee_exec` example
- Added "Automatic git auth" to features table
- Added new "Git operations" section showing how `git push/pull/clone` works automatically with GitHub tokens

### docs/runner-authority.md
- Documented `cwd` parameter with example
- Documented agent identity forwarding (per-agent MCP sessions through Runner)
- Documented GitHub App token minting in exec mode
- Documented automatic `GIT_ASKPASS` script creation for git commands

Small change — just filling in doc gaps for features that already shipped.