### PR TITLE
fix: update sitemap.xml and llms.txt for current site structure

### DIFF
--- a/website/llms.txt
+++ b/website/llms.txt
@@ -7,11 +7,13 @@
 Janee is a secrets management tool designed specifically for AI agents. It solves the problem of giving agents raw API keys by providing:
 
 - **Local-first storage**: API keys never leave your machine (stored encrypted in ~/.janee/)
-- **MCP integration**: Native plugin for OpenClaw and other MCP-compatible AI platforms
+- **MCP integration**: Native Model Context Protocol server exposing tools for AI agents
+- **Runner/Authority architecture**: Runner (untrusted, agent-facing) and Authority (trusted, secret-holding) split for defense in depth
 - **Enforcement-based security**: Server-side path-based policies that agents cannot bypass
 - **Audit logging**: Every request is logged with full context
 - **Exec mode**: Agents can run whitelisted CLI commands with credentials injected via env vars
 - **Agent-scoped credentials**: Per-agent identity and permission scoping
+- **SIGHUP config reload**: Update service configs without restarting long-running servers
 
 ## Installation
 
@@ -19,6 +21,15 @@ Janee is a secrets management tool designed specifically for AI agents. It solve
 npm install -g @true-and-useful/janee
 janee init
 ```
+
+## Architecture
+
+Janee uses a Runner/Authority split:
+
+- **Runner**: Runs in the agent's environment. Handles MCP protocol, tool dispatch, and request validation. Never holds secrets.
+- **Authority**: Runs separately (or same process in dev). Holds encrypted credentials, enforces policies, injects auth into outbound requests.
+
+This means a compromised agent can only access what policies allow — it never sees raw API keys.
 
 ## Key Features
 
@@ -28,76 +39,27 @@ janee init
 - **Command whitelisting**: Only explicitly allowed CLI commands can run; shell metacharacters blocked
 - **Agent-scoped credentials**: Transport-bound identity resolution — each agent gets its own credential scope
 - **Encrypted key storage**: AES-256-GCM encryption for all stored credentials
-- **MCP server mode**: Expose tools (`janee_list_services`, `janee_execute`, `janee_exec`) for AI agents
+- **MCP server mode**: Expose tools (`list_services`, `execute`, `exec`) for AI agents
 - **Docker-ready**: Multi-stage Dockerfile with health checks for containerized deployment
 - **janee status**: One command to check services, sessions, audit log, encryption status (JSON output available)
 - **Interactive CLI**: Easy setup with `janee add` and `janee add --exec` for configuring services
+- **Accessible flag**: `list_services` returns all capabilities with an `accessible` field so agents know what they can use
+
+## Documentation
+
+- Quickstart: https://janee.io/docs/quickstart
+- How It Works: https://janee.io/docs/how-it-works
+- CLI Reference: https://janee.io/docs/cli
+- API Reference: https://janee.io/docs/api
+- Security Model: https://janee.io/docs/security-model
+- Providers: https://janee.io/docs/providers
+- MCP Integration: https://janee.io/docs/mcp-integration
+- Runner/Authority: https://janee.io/docs/runner-authority
+- Policies: https://janee.io/docs/policies
 
 ## Links
 
+- Website: https://janee.io
 - GitHub: https://github.com/rsdouglas/janee
-- npm package: https://www.npmjs.com/package/@true-and-useful/janee
-- OpenClaw plugin: https://www.npmjs.com/package/@openclaw/janee
-- Documentation: https://github.com/rsdouglas/janee/blob/main/README.md
-
-## How It Works
-
-### HTTP API Proxy
-1. Store API keys in Janee: `janee add`
-2. Configure path-based policies (e.g., "allow GET *, deny POST *")
-3. Agent requests access via MCP tools
-4. Janee enforces policies server-side and proxies requests
-5. All requests are logged with full audit trail
-
-### CLI Exec Mode
-1. Configure a CLI tool: `janee add --exec`
-2. Define allowed commands and env var mappings
-3. Agent calls `exec(service, args)` via MCP
-4. Janee injects credentials as env vars, runs the command in a sandboxed subprocess
-5. Output is scrubbed for any leaked secrets before returning
-
-### Agent Scoping
-1. Each agent is identified by transport-bound identity (stdio PID, HTTP session)
-2. Credentials are granted per-agent: `janee grant --agent coding-agent --service github`
-3. Agent only sees services explicitly granted to it
-4. Revoke per-agent: `janee revoke --agent coding-agent --service github`
-
-Example policy:
-```yaml
-capabilities:
-  stripe_readonly:
-    service: stripe
-    rules:
-      allow: [GET *]
-      deny: [POST *, DELETE *]
-```
-
-## Architecture
-
-- **CLI-first**: Install globally, use immediately
-- **Local storage**: ~/.janee/config.yaml (encrypted keys)
-- **MCP interface**: OpenClaw plugin spawns `janee serve` as subprocess
-- **Transport modes**: stdio (local) or HTTP (Docker/remote)
-- **Docker**: Multi-stage build, non-root user, health checks at `/health`
-
-## Use Cases
-
-- Giving AI assistants access to Stripe, GitHub, Gmail APIs with granular permissions
-- Running autonomous agents with read-only access to production systems
-- Delegating API access to agents without exposing raw credentials
-- Letting agents run CLI tools (git, aws, docker) without seeing credentials
-- Multi-agent setups where each agent needs different permissions
-
-## Security Model
-
-**The differentiator**: Enforcement-based, not trust-based. Agent provides intent, but Janee validates every request against configured policies. Agent cannot bypass rules even with plausible reasoning.
-
-- Keys encrypted at rest (AES-256-GCM)
-- Keys injected at request time, never exposed to agent context
-- Shell metacharacters blocked in exec mode
-- Secret scrubbing on all command output
-- Per-agent credential scoping prevents lateral access
-
----
-
-Built by the team behind OpenClaw. Open source, MIT licensed. Available on npm.
+- npm: https://www.npmjs.com/package/@true-and-useful/janee
+- Blog: https://janee.io/blog/

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,18 +1,112 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- Homepage -->
   <url>
     <loc>https://janee.io/</loc>
-    <lastmod>2026-02-13</lastmod>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+
+  <!-- Documentation -->
+  <url>
+    <loc>https://janee.io/docs/</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/quickstart</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/installation</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/how-it-works</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/cli</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/api</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/providers</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/mcp-integration</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/security-model</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/policies</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/runner-authority</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- Blog -->
   <url>
     <loc>https://janee.io/blog/</loc>
-    <lastmod>2026-02-13</lastmod>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://janee.io/blog/why-agents-need-secrets-manager</loc>
     <lastmod>2026-02-13</lastmod>
+    <changefreq>yearly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/blog/how-openseed-secures-agents</loc>
+    <lastmod>2026-02-23</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/blog/runner-authority-split</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <!-- LLM-friendly -->
+  <url>
+    <loc>https://janee.io/llms.txt</loc>
+    <lastmod>2026-02-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Problem

The sitemap.xml only had 3 URLs from Feb 13 — homepage, blog index, and one blog post. But the site now has 11 docs pages, 3 blog posts, and an llms.txt endpoint. Search engines weren't discovering most of the content.

The llms.txt also still referenced "OpenClaw" and didn't mention the Runner/Authority architecture or link to any docs pages.

## Changes

### sitemap.xml
- Added all 11 docs pages with proper priority (0.7-0.9)
- Added all 3 blog posts
- Added llms.txt endpoint
- Added `changefreq` hints for each URL
- Updated `lastmod` dates to reflect actual content dates

### llms.txt
- Added Runner/Authority architecture section
- Updated feature list: accessible flag, SIGHUP reload
- Added full documentation links to all docs pages
- Removed stale "OpenClaw" reference
- Added website link

## Impact

Better search engine coverage of the docs and blog content. LLM crawlers (Anthropic, OpenAI, etc.) get a complete picture of Janee's capabilities via llms.txt.