### PR TITLE
feat: agent registry with secret-based verification for HTTP sessions

### DIFF
--- a/src/core/agent-registry.test.ts
+++ b/src/core/agent-registry.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for agent-registry: verified agent identity
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  loadAgentRegistry,
+  verifyAgentAuth,
+  generateAgentSecret,
+  type AgentRegistry,
+} from './agent-registry.js';
+
+// We need to test without actual encryption for unit tests
+// Create a mock registry directly instead of going through loadAgentRegistry with encryption
+
+function makeRegistry(
+  agents: Record<string, string>,
+  mode: 'http' | 'all' | false = false
+): AgentRegistry {
+  const map = new Map<string, { secret: string }>();
+  for (const [id, secret] of Object.entries(agents)) {
+    map.set(id, { secret });
+  }
+  return { agents: map, requireVerifiedIdentity: mode };
+}
+
+describe('verifyAgentAuth', () => {
+  it('verifies a correct secret', () => {
+    const registry = makeRegistry({ 'agent:alpha': 'secret123' });
+    const result = verifyAgentAuth(registry, 'agent:alpha', 'secret123');
+    expect(result.verified).toBe(true);
+    expect(result.agentId).toBe('agent:alpha');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('rejects an incorrect secret', () => {
+    const registry = makeRegistry({ 'agent:alpha': 'secret123' });
+    const result = verifyAgentAuth(registry, 'agent:alpha', 'wrong');
+    expect(result.verified).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects missing secret for registered agent', () => {
+    const registry = makeRegistry({ 'agent:alpha': 'secret123' });
+    const result = verifyAgentAuth(registry, 'agent:alpha', undefined);
+    expect(result.verified).toBe(false);
+    expect(result.error).toContain('no secret provided');
+  });
+
+  it('allows unregistered agent when no enforcement', () => {
+    const registry = makeRegistry({ 'agent:alpha': 'secret123' }, false);
+    const result = verifyAgentAuth(registry, 'agent:beta', undefined);
+    expect(result.verified).toBe(false);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('rejects unregistered agent when enforcement is on', () => {
+    const registry = makeRegistry({ 'agent:alpha': 'secret123' }, 'http');
+    const result = verifyAgentAuth(registry, 'agent:beta', undefined);
+    expect(result.verified).toBe(false);
+    expect(result.error).toContain('not registered');
+  });
+
+  it('allows unregistered when enforcement on but no agents registered', () => {
+    const registry = makeRegistry({}, 'http');
+    const result = verifyAgentAuth(registry, 'agent:beta', undefined);
+    expect(result.verified).toBe(false);
+    expect(result.error).toBeUndefined();
+  });
+});
+
+describe('loadAgentRegistry', () => {
+  it('parses enforcement mode from server config', () => {
+    const reg = loadAgentRegistry(undefined, { requireVerifiedIdentity: 'http' }, undefined);
+    expect(reg.requireVerifiedIdentity).toBe('http');
+    expect(reg.agents.size).toBe(0);
+  });
+
+  it('defaults enforcement to false', () => {
+    const reg = loadAgentRegistry(undefined, undefined, undefined);
+    expect(reg.requireVerifiedIdentity).toBe(false);
+  });
+
+  it('treats boolean true as http mode', () => {
+    const reg = loadAgentRegistry(undefined, { requireVerifiedIdentity: true }, undefined);
+    expect(reg.requireVerifiedIdentity).toBe('http');
+  });
+});
+
+describe('generateAgentSecret', () => {
+  it('generates a base64url string', () => {
+    const secret = generateAgentSecret();
+    expect(secret).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(secret.length).toBeGreaterThan(20);
+  });
+
+  it('generates unique secrets', () => {
+    const s1 = generateAgentSecret();
+    const s2 = generateAgentSecret();
+    expect(s1).not.toBe(s2);
+  });
+});

--- a/src/core/agent-registry.ts
+++ b/src/core/agent-registry.ts
@@ -1,0 +1,136 @@
+/**
+ * Agent Registry — verified identity for HTTP-connected agents
+ *
+ * Provides secret-based authentication during MCP initialize handshake.
+ * Agents registered here can prove their identity with a shared secret,
+ * which gets stored as `verifiedAgentId` (Priority 1) in the session.
+ *
+ * ## Trust model
+ *
+ * - stdio clients: trusted by transport (clientInfo.name is sufficient)
+ * - HTTP clients: self-reported clientInfo.name is untrusted unless
+ *   verified via this registry
+ *
+ * ## Config format
+ *
+ * ```yaml
+ * agents:
+ *   creature:secure:
+ *     secret: ENC[aes256gcm,data:...,iv:...,tag:...]
+ *   creature:voyager:
+ *     secret: ENC[aes256gcm,data:...,iv:...,tag:...]
+ *
+ * server:
+ *   requireVerifiedIdentity: http  # "http" | "all" | false
+ * ```
+ */
+
+import crypto from 'crypto';
+import { decryptSecret } from './crypto.js';
+
+export interface AgentRegistryEntry {
+  /** The plaintext shared secret (decrypted at load time) */
+  secret: string;
+}
+
+export interface AgentRegistry {
+  /** Map from agentId to registry entry */
+  agents: Map<string, AgentRegistryEntry>;
+  /** Enforcement mode */
+  requireVerifiedIdentity: 'http' | 'all' | false;
+}
+
+/**
+ * Parse agent registry from config.yaml agents section.
+ *
+ * @param agentsConfig - Raw `agents` section from config.yaml
+ * @param serverConfig - Raw `server` section from config.yaml
+ * @param masterKey - Master encryption key for decrypting secrets
+ */
+export function loadAgentRegistry(
+  agentsConfig: Record<string, { secret: string }> | undefined,
+  serverConfig: { requireVerifiedIdentity?: string | boolean } | undefined,
+  masterKey: string | undefined
+): AgentRegistry {
+  const agents = new Map<string, AgentRegistryEntry>();
+
+  if (agentsConfig && masterKey) {
+    for (const [agentId, entry] of Object.entries(agentsConfig)) {
+      if (!entry.secret) {
+        throw new Error(`Agent "${agentId}" is missing a secret in config`);
+      }
+      // Decrypt the stored secret
+      const plainSecret = decryptSecret(entry.secret, masterKey);
+      agents.set(agentId, { secret: plainSecret });
+    }
+  }
+
+  // Parse enforcement mode
+  let requireVerifiedIdentity: 'http' | 'all' | false = false;
+  if (serverConfig?.requireVerifiedIdentity) {
+    const val = serverConfig.requireVerifiedIdentity;
+    if (val === 'http' || val === 'all') {
+      requireVerifiedIdentity = val;
+    } else if (val === true) {
+      requireVerifiedIdentity = 'http'; // boolean true defaults to http-only
+    }
+  }
+
+  return { agents, requireVerifiedIdentity };
+}
+
+/**
+ * Verify an agent's secret during MCP initialize.
+ *
+ * @param registry - Loaded agent registry
+ * @param claimedAgentId - The clientInfo.name from the initialize handshake
+ * @param providedSecret - The secret from params._auth.secret
+ * @returns The verified agentId if auth succeeds, undefined otherwise
+ */
+export function verifyAgentAuth(
+  registry: AgentRegistry,
+  claimedAgentId: string,
+  providedSecret: string | undefined
+): { verified: boolean; agentId?: string; error?: string } {
+  const entry = registry.agents.get(claimedAgentId);
+
+  // Agent not in registry — no verification possible
+  if (!entry) {
+    if (registry.requireVerifiedIdentity === 'all' || registry.requireVerifiedIdentity === 'http') {
+      // If enforcement is on but no agents are registered, allow through
+      // (only enforce when the agent IS registered but fails auth)
+      if (registry.agents.size === 0) {
+        return { verified: false };
+      }
+      return { verified: false, error: `Agent "${claimedAgentId}" is not registered` };
+    }
+    // No enforcement — allow unverified
+    return { verified: false };
+  }
+
+  // Agent is registered — secret is required
+  if (!providedSecret) {
+    return { verified: false, error: `Agent "${claimedAgentId}" is registered but no secret provided` };
+  }
+
+  // Constant-time comparison to prevent timing attacks
+  const expected = Buffer.from(entry.secret, 'utf8');
+  const provided = Buffer.from(providedSecret, 'utf8');
+
+  if (expected.length !== provided.length) {
+    return { verified: false, error: 'Invalid agent secret' };
+  }
+
+  if (!crypto.timingSafeEqual(expected, provided)) {
+    return { verified: false, error: 'Invalid agent secret' };
+  }
+
+  return { verified: true, agentId: claimedAgentId };
+}
+
+/**
+ * Generate a random agent secret suitable for registration.
+ */
+export function generateAgentSecret(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}


### PR DESCRIPTION
## Summary

Foundation module for #96 (Hardened agent identity: session-bound verified authentication).

Implements the core agent registry that enables secret-based verification during MCP initialize handshakes over HTTP.

## What's included

- **`AgentRegistry` type** — stores per-agent secrets with enforcement configuration
- **`loadAgentRegistry()`** — parses `agents` section from config.yaml, decrypts stored secrets
- **`verifyAgentAuth()`** — constant-time (timing-safe) secret comparison during initialize
- **`generateAgentSecret()`** — crypto-random base64url secret generation for CLI flows
- **Enforcement modes**: `'http'` (only HTTP sessions), `'all'` (all transports), or `false` (permissive)
- **11 passing tests** covering all verification paths

## Config format

```yaml
agents:
  creature:secure:
    secret: ENC[aes256gcm,data:...,iv:...,tag:...]

server:
  requireVerifiedIdentity: http
```

## Design decisions

- **Constant-time comparison** via `crypto.timingSafeEqual` to prevent timing attacks
- **Empty registry = permissive** — enforcement only activates when agents are registered, so existing setups aren't broken
- **Decryption at load time** — secrets are decrypted once using the master key, not on every auth check
- **Transport-aware** — stdio clients remain trusted by default; verification targets HTTP sessions

## Next steps (follow-up PRs)

1. Wire into `captureClientInfo()` to extract `_auth` from initialize params
2. Add CLI commands: `janee agent register`, `janee agent revoke`, `janee agent list`
3. Store `verifiedAgentId` in session for policy enforcement in `agent-scope.ts`
4. Docs page for the agent identity system