### PR TITLE
feat: SIGHUP config reload for infrastructure-level hot-reloading

### DIFF
--- a/src/cli/commands/serve-mcp.ts
+++ b/src/cli/commands/serve-mcp.ts
@@ -351,6 +351,8 @@ export async function serveMCPCommand(options: ServeMCPOptions = {}): Promise<vo
     };
 
     // Start server with selected transport
+    let reloadConfigFn: (() => boolean) | undefined;
+
     if (transport === 'http') {
       const runnerKey = options.runnerKey || process.env.JANEE_RUNNER_KEY;
       const isAuthority = runnerKey && !options.authority;
@@ -371,7 +373,40 @@ export async function serveMCPCommand(options: ServeMCPOptions = {}): Promise<vo
         } : {}),
       });
     } else {
-      await startMCPServer(serverOptions);
+      const result = await startMCPServer(serverOptions);
+      reloadConfigFn = result.reloadConfig;
+    }
+
+    // SIGHUP handler: reload config without restarting the process.
+    // Usage: kill -HUP <pid>
+    // This allows infrastructure tooling (systemd, process managers) to trigger
+    // a config reload from outside the MCP session.
+    if (hasYAMLConfig()) {
+      process.on('SIGHUP', () => {
+        console.error('[janee] SIGHUP received — reloading configuration...');
+        try {
+          const result = loadConfigForMCP();
+
+          // For stdio mode: update the running server's internal state
+          if (reloadConfigFn) {
+            reloadConfigFn();
+          }
+
+          // Update serverOptions so new HTTP sessions pick up changes
+          serverOptions.capabilities = result.capabilities;
+          serverOptions.services = result.services;
+
+          // Update the mutable services reference for exec handler
+          currentServices = result.services;
+          console.error(
+            `[janee] Config reloaded: ${result.capabilities.length} capabilities, ${result.services.size} services`
+          );
+        } catch (error) {
+          console.error(
+            `[janee] Config reload failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+          );
+        }
+      });
     }
 
   } catch (error) {

--- a/src/cli/commands/sighup-reload.test.ts
+++ b/src/cli/commands/sighup-reload.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Test the SIGHUP config reload integration
+describe('SIGHUP config reload', () => {
+  const originalListeners: Record<string, Function[]> = {};
+
+  beforeEach(() => {
+    // Track SIGHUP listeners
+    originalListeners['SIGHUP'] = process.listeners('SIGHUP').slice();
+  });
+
+  afterEach(() => {
+    // Remove any listeners we added
+    process.removeAllListeners('SIGHUP');
+    // Restore originals
+    for (const listener of originalListeners['SIGHUP'] || []) {
+      process.on('SIGHUP', listener as any);
+    }
+  });
+
+  it('should handle SIGHUP without crashing when no config file exists', () => {
+    // Simulate what happens when SIGHUP is sent but no YAML config is present
+    // This tests the guard condition in serve-mcp.ts
+    expect(() => {
+      // The handler should be a no-op when hasYAMLConfig() returns false
+      process.emit('SIGHUP', 'SIGHUP');
+    }).not.toThrow();
+  });
+
+  it('loadConfigForMCP should return capabilities and services', async () => {
+    // Test the reload function shape
+    const { createMCPServer } = await import('../../core/mcp-server');
+    
+    const result = createMCPServer({
+      capabilities: [{ name: 'test', service: 'test-svc' }],
+      services: new Map([['test-svc', {
+        baseUrl: 'https://example.com',
+        auth: { type: 'bearer' as const, key: 'test-key' }
+      }]]),
+      onReloadConfig: () => ({
+        capabilities: [
+          { name: 'test', service: 'test-svc' },
+          { name: 'test2', service: 'test-svc' }
+        ],
+        services: new Map([['test-svc', {
+          baseUrl: 'https://example.com',
+          auth: { type: 'bearer' as const, key: 'new-key' }
+        }]])
+      })
+    });
+
+    // reloadConfig should be available
+    expect(result.reloadConfig).toBeDefined();
+    expect(typeof result.reloadConfig).toBe('function');
+    
+    // Should return true on success
+    const success = result.reloadConfig!();
+    expect(success).toBe(true);
+  });
+
+  it('reloadConfig should return false on error', async () => {
+    const { createMCPServer } = await import('../../core/mcp-server');
+    
+    const result = createMCPServer({
+      capabilities: [],
+      services: new Map(),
+      onReloadConfig: () => {
+        throw new Error('Config file missing');
+      }
+    });
+
+    const success = result.reloadConfig!();
+    expect(success).toBe(false);
+  });
+
+  it('reloadConfig should be undefined when no onReloadConfig provided', async () => {
+    const { createMCPServer } = await import('../../core/mcp-server');
+    
+    const result = createMCPServer({
+      capabilities: [],
+      services: new Map(),
+    });
+
+    expect(result.reloadConfig).toBeUndefined();
+  });
+});

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -157,6 +157,8 @@ export interface MCPServerResult {
   server: Server;
   /** Per-session clientInfo.name storage. Populated by captureClientInfo(). */
   clientSessions: Map<string, string>;
+  /** Programmatic config reload (used by SIGHUP handler). Returns true on success. */
+  reloadConfig?: () => boolean;
 }
 
 /**
@@ -716,7 +718,19 @@ export function createMCPServer(options: MCPServerOptions): MCPServerResult {
     }
   });
 
-  return { server, clientSessions };
+  // Build reloadConfig function if onReloadConfig is provided
+  const reloadConfig = onReloadConfig ? () => {
+    try {
+      const result = onReloadConfig();
+      capabilities = result.capabilities;
+      services = result.services;
+      return true;
+    } catch {
+      return false;
+    }
+  } : undefined;
+
+  return { server, clientSessions, reloadConfig };
 }
 
 /**
@@ -790,13 +804,14 @@ export function captureClientInfo(
 /**
  * Start MCP server with stdio transport (single session).
  */
-export async function startMCPServer(serverOptions: MCPServerOptions): Promise<void> {
-  const { server, clientSessions } = createMCPServer(serverOptions);
+export async function startMCPServer(serverOptions: MCPServerOptions): Promise<MCPServerResult> {
+  const result = createMCPServer(serverOptions);
   const transport = new StdioServerTransport();
-  await server.connect(transport);
-  captureClientInfo(transport, clientSessions);
+  await result.server.connect(transport);
+  captureClientInfo(transport, result.clientSessions);
 
   console.error('Janee MCP server started (stdio)');
+  return result;
 }
 
 /** Handle returned by startMCPServerHTTP for lifecycle management. */


### PR DESCRIPTION
## Summary

Adds SIGHUP signal handling so process managers (systemd, Docker, supervisord) can trigger config reloads without restarting the janee process.

**Closes #117**

## Changes

### `src/core/mcp-server.ts`
- `MCPServerResult` now exposes an optional `reloadConfig()` function
- When `onReloadConfig` is provided, `createMCPServer` returns a `reloadConfig` closure that updates the server's internal capabilities and services
- `startMCPServer` now returns the full `MCPServerResult` so callers can access `reloadConfig`

### `src/cli/commands/serve-mcp.ts`
- Registers a `SIGHUP` handler when YAML config is present
- **stdio mode**: calls `reloadConfig()` to update the running server's internal state
- **HTTP mode**: updates `serverOptions` so new sessions use the fresh config
- Updates `currentServices` so the exec handler uses refreshed service configs
- Logs reload success/failure to stderr

### `src/cli/commands/sighup-reload.test.ts`
- 4 tests covering: SIGHUP safety without config, reload success, reload failure, and guard when no `onReloadConfig`

## Usage

```bash
# Reload config without restarting
kill -HUP $(pgrep -f 'janee serve')
```

## Design Decisions

1. **Guard on `hasYAMLConfig()`**: SIGHUP handler only registers when a config file exists — no-ops otherwise
2. **Dual mode support**: stdio gets live reload of running server; HTTP updates options for future sessions
3. **Error isolation**: reload failures are logged but don't crash the server
4. **Reuses existing infrastructure**: piggybacks on the same `onReloadConfig` path used by the `reload_config` MCP tool