### PR TITLE
fix: complete sitemap coverage and add JSON-LD structured data

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -646,6 +646,31 @@
       .nav-links a { font-size: 0.8rem; }
     }
   </style>
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Janee",
+    "description": "Secrets management for AI agents via MCP. Give AI agents scoped, auditable API access without exposing your keys.",
+    "url": "https://janee.io",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "macOS, Linux, Windows",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "author": {
+      "@type": "Organization",
+      "name": "True and Useful",
+      "url": "https://github.com/rsdouglas/janee"
+    },
+    "codeRepository": "https://github.com/rsdouglas/janee",
+    "programmingLanguage": "TypeScript",
+    "license": "https://opensource.org/licenses/MIT"
+  }
+  </script>
 </head>
 <body>
   <nav>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,18 +1,104 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <!-- Homepage -->
   <url>
     <loc>https://janee.io/</loc>
-    <lastmod>2026-02-13</lastmod>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+
+  <!-- Documentation -->
+  <url>
+    <loc>https://janee.io/docs/</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/quickstart</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/installation</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/how-it-works</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/security-model</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/providers</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/policies</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/mcp-integration</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/runner-authority</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/cli</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/docs/api</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <!-- Blog -->
   <url>
     <loc>https://janee.io/blog/</loc>
-    <lastmod>2026-02-13</lastmod>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://janee.io/blog/why-agents-need-secrets-manager</loc>
     <lastmod>2026-02-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/blog/runner-authority-split</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://janee.io/blog/how-openseed-secures-agents</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Problem

The sitemap only lists 3 of 16 pages — the docs section (10 pages) and newer blog posts are invisible to search engines. There's also no structured data markup, so Google can't display rich results for janee.

## Changes

**Sitemap** (website/sitemap.xml):
- Expanded from 3 → 16 URLs covering all docs and blog pages
- Added `changefreq` hints for crawlers (weekly for docs index, monthly for reference pages)
- Updated `lastmod` dates

**Structured Data** (website/index.html):
- Added JSON-LD `SoftwareApplication` schema to homepage
- Includes: name, description, category, repository URL, license, pricing (free)
- Enables rich search results (software panels, knowledge graph entries)

No functional changes — this only affects search engine indexing.

## Why this matters

Janee.io is live and indexed but search engines are only crawling 3 pages. The docs section is the most valuable content for discoverability (people searching for 'MCP secrets management', 'AI agent API access', etc.) and it's currently not in the sitemap.