### PR TITLE
fix: CLI gotcha audit + consolidate duplicated access/TTL logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,8 @@ janee add                     # Add a service (interactive)
 janee add stripe -u https://api.stripe.com -k sk_xxx  # Add with args
 janee remove <service>        # Remove a service
 janee remove <service> --yes  # Remove without confirmation
+janee overview                # One-screen summary of who can access what
+janee overview --json         # Output as JSON
 janee list                    # List configured services
 janee list --json             # Output as JSON (for integrations)
 janee search [query]          # Search service directory
@@ -606,7 +608,27 @@ janee logs --json             # Output as JSON
 janee sessions                # List active sessions
 janee sessions --json         # Output as JSON
 janee revoke <id>             # Kill a session
+janee status                  # Config and health status
+janee whoami --agent <name>   # Preview what an agent can access
+janee diagnose access <cap> --agent <name>  # Trace why access is allowed/denied
 ```
+
+### Overview
+
+`janee overview` gives you a one-screen summary of your entire configuration — which agents can access which capabilities, and whether anything is unreachable:
+
+```
+  22 services, 32 capabilities    (defaultAccess: restricted)
+
+  creature:must-trade: bybit, serper
+  creature:proof-ceo: gh-proof-ceo-proxy, cloudflare, resend, serper, ...
+  cursor-vscode: devto, cloudflare, serper, proof-admin, twitter, ...
+
+  Unreachable: mexc, google-analytics, fal
+  (no known agent can access these)
+```
+
+Agent-specific access (via `allowedAgents`) is colored cyan; globally open access (via `access: open` or default policy) is colored green. Use `--json` for machine-readable output.
 
 ### Non-interactive Setup (for AI agents)
 
@@ -671,7 +693,7 @@ Agent never touches the real key.
 - **Encryption**: Keys stored with AES-256-GCM
 - **Agent identity**: Derived from `clientInfo.name` in the MCP initialize handshake — no custom headers needed
 - **Agent isolation**: Each agent gets its own session with isolated identity (HTTP transport creates a Server+Transport per session)
-- **Access control**: Per-capability `allowedAgents` whitelist + server-wide `defaultAccess` policy
+- **Access control**: Per-capability `allowedAgents` whitelist + server-wide `defaultAccess` policy + per-capability `access: open/restricted` override
 - **Credential scoping**: Agent-created credentials default to `agent-only`
 - **Audit log**: Every request logged to `~/.janee/logs/`
 - **Sessions**: Time-limited, revocable

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,24 @@ All notable changes to Janee will be documented in this file.
 
 ## [Unreleased]
 
-_(empty)_
+### Fixed
+
+- **`whoami` and `doctor bundle` now respect per-capability `access` field** — Both commands were only checking the global `defaultAccess`, ignoring capability-level `access: open/restricted` overrides. This could report incorrect access for agents.
+- **Contradictory CLI flags now error** — `--allowed-agents` + `--clear-agents`, `--access` + `--clear-access`, and `--clear-rules` + `--allow`/`--deny` now produce a clear error instead of silently discarding one option.
+- **`cap add --mode exec` without `--allow-commands` now errors** — Previously created an unusable exec-mode capability with no allowed commands.
+- **`janee add --timeout` validates input** — Invalid values (NaN, zero, negative) now error instead of saving broken config.
+- **TTL format validated at save time** — `janee cap add --ttl garbage` now errors with expected format hint.
+- **`cap edit` with no options now errors** — Previously reported silent success with no changes made.
+- **`--access` help text corrected** — Removed nonexistent "inherit" option; points to `--clear-access` instead.
+- **`--access` warning scoped correctly** — Warning about `allowedAgents` precedence no longer fires when both are set in the same command.
+- **`revoke` prefix ambiguity check** — Ambiguous session ID prefixes now error with a list of matches instead of silently revoking the first.
+- **`logs --json --follow` error format** — Normalized to `{ ok: false, error }` for consistency.
+
+### Changed
+
+- **Consolidate access evaluation** — `canAccessCapability()` and `resolveAccess()` extracted to `agent-scope.ts` as single source of truth. Removed 5 duplicated implementations from `mcp-server.ts`, `whoami.ts`, `doctor-bundle.ts`, `overview.ts`, `authority.ts`, and `tool-handlers.ts`.
+- **Consolidate TTL logic** — `validateTTL()` and `parseTTL()` extracted to `types.ts`. Removed duplicates from `capability.ts` and `tool-handlers.ts`.
+- **`janee overview` colors** — Capabilities colored by access type: cyan for agent-specific (`allowedAgents`), green for globally open. Warns on exec/proxy mode option mismatches.
 
 ## [0.16.0] - 2026-03-17
 

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -677,7 +677,12 @@ export async function addCommand(
         if (options.allowCommands) capConfig.allowCommands = options.allowCommands;
         if (options.envMap) capConfig.env = parseEnvMap(options.envMap);
         if (options.workDir) capConfig.workDir = options.workDir;
-        if (options.timeout) capConfig.timeout = parseInt(options.timeout, 10);
+        if (options.timeout) {
+          capConfig.timeout = parseInt(options.timeout, 10);
+          if (isNaN(capConfig.timeout) || capConfig.timeout <= 0) {
+            throw new Error(`Invalid timeout "${options.timeout}"`);
+          }
+        }
       }
       config.capabilities[serviceName] = capConfig;
       saveYAMLConfig(config);

--- a/src/cli/commands/capability.ts
+++ b/src/cli/commands/capability.ts
@@ -1,3 +1,4 @@
+import { validateTTL } from '../../core/types';
 import {
   cliError,
   handleCommandError,
@@ -98,7 +99,14 @@ interface CapAddEditOptions {
   json?: boolean;
 }
 
-function applyCapabilityOptions(cap: CapabilityConfig, options: CapAddEditOptions): void {
+function applyCapabilityOptions(cap: CapabilityConfig, options: CapAddEditOptions, hadAllowedAgents = false): void {
+  if (options.allowedAgents && options.clearAgents) {
+    throw new Error('Conflicting options: --allowed-agents and --clear-agents cannot be used together');
+  }
+  if (options.access && options.clearAccess) {
+    throw new Error('Conflicting options: --access and --clear-access cannot be used together');
+  }
+
   if (options.allowedAgents) {
     cap.allowedAgents = options.allowedAgents.flatMap(a => a.split(',').map(s => s.trim()).filter(Boolean));
   }
@@ -109,6 +117,10 @@ function applyCapabilityOptions(cap: CapabilityConfig, options: CapAddEditOption
     if (options.access !== 'open' && options.access !== 'restricted') {
       throw new Error(`Invalid access policy "${options.access}" — must be "open" or "restricted"`);
     }
+    if (hadAllowedAgents && !options.clearAgents && !options.allowedAgents) {
+      console.error(`⚠️  This capability has allowedAgents, which take precedence over --access.`);
+      console.error(`   To apply access policy, also pass --clear-agents.`);
+    }
     cap.access = options.access;
   }
   if (options.clearAccess) {
@@ -117,6 +129,9 @@ function applyCapabilityOptions(cap: CapabilityConfig, options: CapAddEditOption
   if (options.mode) {
     if (options.mode !== 'proxy' && options.mode !== 'exec') {
       throw new Error(`Invalid mode "${options.mode}" — must be "proxy" or "exec"`);
+    }
+    if (options.mode === 'exec' && !options.allowCommands?.length && !cap.allowCommands?.length) {
+      throw new Error('Exec mode requires --allow-commands');
     }
     cap.mode = options.mode;
   }
@@ -131,7 +146,12 @@ function applyCapabilityOptions(cap: CapabilityConfig, options: CapAddEditOption
   }
   if (options.timeout) {
     cap.timeout = parseInt(options.timeout, 10);
-    if (isNaN(cap.timeout)) throw new Error(`Invalid timeout "${options.timeout}"`);
+    if (isNaN(cap.timeout) || cap.timeout <= 0) throw new Error(`Invalid timeout "${options.timeout}"`);
+  }
+
+  const effectiveMode = cap.mode ?? 'proxy';
+  if (effectiveMode === 'proxy' && (options.allowCommands || options.envMap || options.workDir || options.timeout)) {
+    console.error(`⚠️  Exec-mode options (--allow-commands, --env-map, --work-dir, --timeout) have no effect on proxy-mode capabilities.`);
   }
 }
 
@@ -156,9 +176,12 @@ export async function capabilityAddCommand(
       cliError(`Service "${options.service}" not found. Add it first with 'janee add'.`, options.json);
     }
 
+    const ttl = options.ttl || '1h';
+    validateTTL(ttl);
+
     const capability: CapabilityConfig = {
       service: options.service,
-      ttl: options.ttl || '1h',
+      ttl,
       autoApprove: options.autoApprove,
       requiresReason: options.requiresReason,
     };
@@ -170,6 +193,10 @@ export async function capabilityAddCommand(
     }
 
     applyCapabilityOptions(capability, options);
+
+    if ((capability.mode === 'exec') && capability.rules) {
+      console.error(`⚠️  Path rules (--allow/--deny) have no effect on exec-mode capabilities. Use --allow-commands instead.`);
+    }
 
     config.capabilities[name] = capability;
     saveYAMLConfig(config);
@@ -210,10 +237,28 @@ export async function capabilityEditCommand(
     }
 
     const capability = config.capabilities[name];
+    const hadAllowedAgents = !!(capability.allowedAgents?.length);
 
-    if (options.ttl) capability.ttl = options.ttl;
+    const hasChanges = options.ttl || options.autoApprove !== undefined ||
+      options.requiresReason !== undefined || options.clearRules || options.allow ||
+      options.deny || options.allowedAgents || options.clearAgents || options.access ||
+      options.clearAccess || options.mode || options.allowCommands || options.envMap ||
+      options.workDir || options.timeout;
+
+    if (!hasChanges) {
+      cliError('No changes specified. See `janee cap edit --help` for options.', options.json);
+    }
+
+    if (options.ttl) {
+      validateTTL(options.ttl);
+      capability.ttl = options.ttl;
+    }
     if (options.autoApprove !== undefined) capability.autoApprove = options.autoApprove;
     if (options.requiresReason !== undefined) capability.requiresReason = options.requiresReason;
+
+    if (options.clearRules && (options.allow || options.deny)) {
+      throw new Error('Conflicting options: --clear-rules and --allow/--deny cannot be used together');
+    }
 
     if (options.clearRules) {
       delete capability.rules;
@@ -223,7 +268,11 @@ export async function capabilityEditCommand(
       if (options.deny) capability.rules.deny = options.deny;
     }
 
-    applyCapabilityOptions(capability, options);
+    applyCapabilityOptions(capability, options, hadAllowedAgents);
+
+    if ((options.allow || options.deny) && (capability.mode === 'exec')) {
+      console.error(`⚠️  Path rules (--allow/--deny) have no effect on exec-mode capabilities. Use --allow-commands instead.`);
+    }
 
     saveYAMLConfig(config);
 

--- a/src/cli/commands/diagnose.ts
+++ b/src/cli/commands/diagnose.ts
@@ -1,6 +1,9 @@
 import { canAgentAccess } from '../../core/agent-scope';
 import { checkRules } from '../../core/rules';
-import { handleCommandError, requireConfig } from '../cli-utils';
+import {
+  handleCommandError,
+  requireConfig,
+} from '../cli-utils';
 import { loadYAMLConfig } from '../config-yaml';
 
 interface TraceStep {

--- a/src/cli/commands/doctor-bundle.ts
+++ b/src/cli/commands/doctor-bundle.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from 'fs';
 
+import { canAccessCapability } from '../../core/agent-scope';
 import {
   AuditEvent,
   AuditLogger,
@@ -96,15 +97,7 @@ export async function doctorBundleCommand(
         const denied: string[] = [];
 
         for (const [name, cap] of Object.entries(config.capabilities)) {
-          const c = cap as any;
-          let allowed = true;
-
-          if (c.allowedAgents && c.allowedAgents.length > 0) {
-            allowed = c.allowedAgents.includes(agentId);
-          } else if (config.server?.defaultAccess === 'restricted') {
-            allowed = false;
-          }
-
+          const allowed = canAccessCapability(agentId, cap, config.services[cap.service], config.server?.defaultAccess);
           (allowed ? accessible : denied).push(name);
         }
 

--- a/src/cli/commands/logs.ts
+++ b/src/cli/commands/logs.ts
@@ -14,7 +14,7 @@ export async function logsCommand(options: {
     if (options.follow) {
       // JSON mode not supported for follow (streaming)
       if (options.json) {
-        console.log(JSON.stringify({ error: '--json not supported with --follow' }, null, 2));
+        console.log(JSON.stringify({ ok: false, error: '--json not supported with --follow' }, null, 2));
         process.exit(1);
       }
 

--- a/src/cli/commands/new-commands.test.ts
+++ b/src/cli/commands/new-commands.test.ts
@@ -184,6 +184,7 @@ describe('capabilityEditCommand — extended flags', () => {
     const cap = captureConsole();
     await capabilityEditCommand('stripe_read', {
       mode: 'exec',
+      allowCommands: ['curl'],
       timeout: '10000',
       json: true,
     });

--- a/src/cli/commands/overview.test.ts
+++ b/src/cli/commands/overview.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import {
+  hasYAMLConfig,
+  loadYAMLConfig,
+} from '../config-yaml';
+import { overviewCommand } from './overview';
 
 vi.mock('../config-yaml', () => ({
   loadYAMLConfig: vi.fn(),
@@ -7,9 +19,6 @@ vi.mock('../config-yaml', () => ({
   getConfigDir: vi.fn(() => '/tmp/janee-test'),
   getAuditDir: vi.fn(() => '/tmp/janee-test/logs'),
 }));
-
-import { loadYAMLConfig, hasYAMLConfig } from '../config-yaml';
-import { overviewCommand } from './overview';
 
 const mockLoad = vi.mocked(loadYAMLConfig);
 const mockHas = vi.mocked(hasYAMLConfig);
@@ -84,7 +93,7 @@ describe('overviewCommand', () => {
     cap.restore();
     const output = cap.logs.join('\n');
     expect(output).toContain('billing-bot');
-    expect(output).toContain('stripe (allowed)');
+    expect(output).toContain('stripe');
     expect(output).toContain('serp');
   });
 

--- a/src/cli/commands/overview.ts
+++ b/src/cli/commands/overview.ts
@@ -1,27 +1,19 @@
-import { canAgentAccess } from '../../core/agent-scope';
-import { handleCommandError, requireConfig } from '../cli-utils';
+import { resolveAccess } from '../../core/agent-scope';
+import {
+  handleCommandError,
+  requireConfig,
+} from '../cli-utils';
 import { loadYAMLConfig } from '../config-yaml';
-import type { CapabilityConfig, ServiceConfig as YAMLServiceConfig } from '../config-yaml';
 
-type AccessPolicy = 'open' | 'restricted' | undefined;
-
-function resolveEffectiveAccess(
-  cap: CapabilityConfig,
-  service: YAMLServiceConfig | undefined,
-  agentId: string,
-  globalDefault: AccessPolicy,
-): 'allowed' | 'denied' | 'open' {
-  if (cap.allowedAgents && cap.allowedAgents.length > 0) {
-    return cap.allowedAgents.includes(agentId) ? 'allowed' : 'denied';
-  }
-
-  const effective = cap.access ?? globalDefault;
-  if (effective === 'restricted') return 'denied';
-
-  if (!canAgentAccess(agentId, service?.ownership)) return 'denied';
-
-  return 'open';
-}
+const useColor = process.stdout.isTTY !== false && !process.env.NO_COLOR;
+const c = {
+  bold:    (s: string) => useColor ? `\x1b[1m${s}\x1b[22m` : s,
+  dim:     (s: string) => useColor ? `\x1b[2m${s}\x1b[22m` : s,
+  green:   (s: string) => useColor ? `\x1b[32m${s}\x1b[39m` : s,
+  yellow:  (s: string) => useColor ? `\x1b[33m${s}\x1b[39m` : s,
+  red:     (s: string) => useColor ? `\x1b[31m${s}\x1b[39m` : s,
+  cyan:    (s: string) => useColor ? `\x1b[36m${s}\x1b[39m` : s,
+};
 
 export async function overviewCommand(options: { json?: boolean } = {}): Promise<void> {
   try {
@@ -42,35 +34,35 @@ export async function overviewCommand(options: { json?: boolean } = {}): Promise
       if (svc.ownership?.createdBy) knownAgents.add(svc.ownership.createdBy);
     }
 
-    // Build per-agent access map
-    const agentAccess: Record<string, { accessible: string[]; denied: string[] }> = {};
+    // Build per-agent access map with access type
+    const agentAccess: Record<string, { accessible: { name: string; type: 'allowed' | 'open' }[]; denied: string[] }> = {};
     for (const agentId of knownAgents) {
-      const accessible: string[] = [];
+      const accessible: { name: string; type: 'allowed' | 'open' }[] = [];
       const denied: string[] = [];
       for (const [name, cap] of capEntries) {
         const svc = config.services[cap.service];
-        const result = resolveEffectiveAccess(cap, svc, agentId, globalDefault);
+        const result = resolveAccess(agentId, cap, svc, globalDefault);
         if (result === 'denied') denied.push(name);
-        else accessible.push(name);
+        else accessible.push({ name, type: result });
       }
       agentAccess[agentId] = { accessible, denied };
     }
 
-    // Find capabilities no known agent can reach
     const unreachable = capEntries.filter(([name]) => {
       if (knownAgents.size === 0) return false;
-      return [...knownAgents].every(agentId => {
-        const { denied } = agentAccess[agentId];
-        return denied.includes(name);
-      });
+      return [...knownAgents].every(agentId => agentAccess[agentId].denied.includes(name));
     }).map(([name]) => name);
 
     if (options.json) {
+      const jsonAgents: Record<string, { accessible: string[]; denied: string[] }> = {};
+      for (const [agentId, data] of Object.entries(agentAccess)) {
+        jsonAgents[agentId] = { accessible: data.accessible.map(a => a.name), denied: data.denied };
+      }
       console.log(JSON.stringify({
         services: serviceNames.length,
         capabilities: capEntries.length,
         globalDefaultAccess: globalDefault ?? 'open',
-        agents: agentAccess,
+        agents: jsonAgents,
         unreachable,
       }, null, 2));
       return;
@@ -78,11 +70,11 @@ export async function overviewCommand(options: { json?: boolean } = {}): Promise
 
     // Human-readable output
     console.log('');
-    console.log(`  ${serviceNames.length} service${serviceNames.length !== 1 ? 's' : ''}, ${capEntries.length} capabilit${capEntries.length !== 1 ? 'ies' : 'y'}    (defaultAccess: ${globalDefault ?? 'open'})`);
+    console.log(`  ${c.bold(`${serviceNames.length}`)} service${serviceNames.length !== 1 ? 's' : ''}, ${c.bold(`${capEntries.length}`)} capabilit${capEntries.length !== 1 ? 'ies' : 'y'}    ${c.dim(`(defaultAccess: ${globalDefault ?? 'open'})`)}`);
     console.log('');
 
     if (capEntries.length === 0) {
-      console.log('  No capabilities configured. Run `janee add <service>` to get started.');
+      console.log(`  No capabilities configured. Run ${c.cyan('janee add <service>')} to get started.`);
       console.log('');
       return;
     }
@@ -90,17 +82,14 @@ export async function overviewCommand(options: { json?: boolean } = {}): Promise
     // Per-agent summary
     if (knownAgents.size > 0) {
       for (const agentId of [...knownAgents].sort()) {
-        const { accessible, denied } = agentAccess[agentId];
+        const { accessible } = agentAccess[agentId];
         if (accessible.length > 0) {
-          const labels = accessible.map(name => {
-            const cap = config.capabilities[name];
-            if (cap.allowedAgents?.includes(agentId)) return `${name} (allowed)`;
-            if (cap.access === 'open') return `${name} (open)`;
-            return name;
-          });
-          console.log(`  ${agentId}: ${labels.join(', ')}`);
+          const labels = accessible.map(a =>
+            a.type === 'allowed' ? c.cyan(a.name) : c.green(a.name)
+          );
+          console.log(`  ${c.bold(agentId)}: ${labels.join(c.dim(', '))}`);
         } else {
-          console.log(`  ${agentId}: (no access)`);
+          console.log(`  ${c.bold(agentId)}: ${c.dim('(no access)')}`);
         }
       }
     } else {
@@ -110,8 +99,8 @@ export async function overviewCommand(options: { json?: boolean } = {}): Promise
     // Unreachable capabilities
     if (unreachable.length > 0) {
       console.log('');
-      console.log(`  Unreachable: ${unreachable.join(', ')}`);
-      console.log('  (no known agent can access these)');
+      console.log(`  ${c.red('Unreachable')}: ${unreachable.map(n => c.yellow(n)).join(', ')}`);
+      console.log(`  ${c.dim('(no known agent can access these)')}`);
     }
 
     console.log('');

--- a/src/cli/commands/revoke.ts
+++ b/src/cli/commands/revoke.ts
@@ -16,15 +16,24 @@ export async function revokeCommand(sessionIdPrefix: string): Promise<void> {
     const data = fs.readFileSync(sessionsFile, 'utf8');
     const sessions: SerializedSession[] = JSON.parse(data);
 
-    // Find session by prefix
-    const session = sessions.find(s => s.id.startsWith(sessionIdPrefix));
+    const matches = sessions.filter(s => s.id.startsWith(sessionIdPrefix));
 
-    if (!session) {
+    if (matches.length === 0) {
       console.error(`❌ Session not found: ${sessionIdPrefix}`);
       console.error('');
       console.error('Run: janee sessions');
       process.exit(1);
     }
+
+    if (matches.length > 1) {
+      console.error(`❌ Ambiguous prefix "${sessionIdPrefix}" matches ${matches.length} sessions. Be more specific.`);
+      for (const m of matches) {
+        console.error(`   ${m.id.substring(0, 24)}... (${m.capability})`);
+      }
+      process.exit(1);
+    }
+
+    const session = matches[0];
 
     if (session.revoked) {
       console.log(`⚠️  Session already revoked: ${session.id.substring(0, 20)}...`);

--- a/src/cli/commands/whoami.ts
+++ b/src/cli/commands/whoami.ts
@@ -1,20 +1,9 @@
-import { canAgentAccess } from '../../core/agent-scope';
-import { handleCommandError, requireConfig } from '../cli-utils';
+import { canAccessCapability } from '../../core/agent-scope';
+import {
+  handleCommandError,
+  requireConfig,
+} from '../cli-utils';
 import { loadYAMLConfig } from '../config-yaml';
-
-function canAccessCapability(
-  agentId: string | undefined,
-  cap: { allowedAgents?: string[]; service: string },
-  services: Record<string, { ownership?: any }>,
-  defaultAccess?: string,
-): boolean {
-  if (!agentId) return true;
-  if (cap.allowedAgents && cap.allowedAgents.length > 0) {
-    return cap.allowedAgents.includes(agentId);
-  }
-  if (defaultAccess === 'restricted') return false;
-  return canAgentAccess(agentId, services[cap.service]?.ownership);
-}
 
 export async function whoamiCommand(
   options: { agent?: string; json?: boolean } = {},
@@ -32,7 +21,7 @@ export async function whoamiCommand(
 
     for (const name of capNames) {
       const cap = config.capabilities[name];
-      if (canAccessCapability(agentId, cap, config.services, defaultAccess)) {
+      if (canAccessCapability(agentId, cap, config.services[cap.service], defaultAccess)) {
         accessible.push(name);
       } else {
         denied.push(name);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -293,7 +293,7 @@ cap
   .option('--clear-rules', 'Clear all rules')
   .option('--allowed-agents <agents...>', 'Restrict to specific agent IDs')
   .option('--clear-agents', 'Remove all agent restrictions')
-  .option('--access <policy>', 'Per-capability access policy: open, restricted, or inherit')
+  .option('--access <policy>', 'Per-capability access policy: open or restricted (use --clear-access to inherit)')
   .option('--clear-access', 'Remove per-capability access override (inherit from global)')
   .option('--mode <mode>', 'Execution mode: proxy or exec')
   .option('--allow-commands <cmds...>', 'Allowed executables for exec mode')

--- a/src/core/agent-scope.ts
+++ b/src/core/agent-scope.ts
@@ -177,3 +177,60 @@ export function revokeAccess(
 
   return updated;
 }
+
+// ---------------------------------------------------------------------------
+// Shared capability access evaluation
+// ---------------------------------------------------------------------------
+
+/** Minimal shape needed for access checks — satisfied by both runtime Capability and CLI CapabilityConfig */
+export interface AccessCheckCapability {
+  allowedAgents?: string[];
+  access?: 'open' | 'restricted';
+  service: string;
+}
+
+/** Minimal shape needed for service ownership lookups */
+export interface AccessCheckService {
+  ownership?: CredentialOwnership;
+}
+
+export type AccessResult = 'allowed' | 'open' | 'denied';
+
+/**
+ * Single source of truth for "can this agent access this capability?"
+ * No agentId (CLI/admin) always gets access.
+ */
+export function canAccessCapability(
+  agentId: string | undefined,
+  cap: AccessCheckCapability,
+  service: AccessCheckService | undefined,
+  defaultAccessPolicy: 'open' | 'restricted' | undefined,
+): boolean {
+  return resolveAccess(agentId, cap, service, defaultAccessPolicy) !== 'denied';
+}
+
+/**
+ * Richer version that returns *how* access was granted:
+ * - 'allowed': agent is explicitly listed in allowedAgents
+ * - 'open': access is open (global or per-capability policy)
+ * - 'denied': agent cannot access
+ */
+export function resolveAccess(
+  agentId: string | undefined,
+  cap: AccessCheckCapability,
+  service: AccessCheckService | undefined,
+  defaultAccessPolicy: 'open' | 'restricted' | undefined,
+): AccessResult {
+  if (!agentId) return 'open';
+
+  if (cap.allowedAgents && cap.allowedAgents.length > 0) {
+    return cap.allowedAgents.includes(agentId) ? 'allowed' : 'denied';
+  }
+
+  const effective = cap.access ?? defaultAccessPolicy;
+  if (effective === 'restricted') return 'denied';
+
+  if (!canAgentAccess(agentId, service?.ownership)) return 'denied';
+
+  return 'open';
+}

--- a/src/core/authority.ts
+++ b/src/core/authority.ts
@@ -1,14 +1,24 @@
-import { randomUUID, timingSafeEqual } from "crypto";
-import express from "express";
+import {
+  randomUUID,
+  timingSafeEqual,
+} from 'crypto';
+import express from 'express';
 
+import { canAccessCapability } from './agent-scope.js';
 import {
   buildExecEnv,
   hashPolicyFingerprint,
   validateCommand,
-} from "./exec.js";
-import { DEFAULT_TIMEOUT_MS } from "./types.js";
-import { getInstallationToken, GitHubAppCredentials } from "./github-app.js";
-import { ServiceTestResult, testServiceConnection } from "./health.js";
+} from './exec.js';
+import {
+  getInstallationToken,
+  GitHubAppCredentials,
+} from './github-app.js';
+import {
+  ServiceTestResult,
+  testServiceConnection,
+} from './health.js';
+import { DEFAULT_TIMEOUT_MS } from './types.js';
 
 export interface RunnerIdentity {
   runnerId: string;
@@ -207,12 +217,7 @@ export function buildAuthorityHooks(
       if (!cap) throw new Error(`Unknown capability: ${req.capabilityId}`);
       if (cap.mode !== "exec") throw new Error("Capability is not exec-mode");
 
-      if (
-        cap.allowedAgents &&
-        cap.allowedAgents.length > 0 &&
-        req.agentId &&
-        !cap.allowedAgents.includes(req.agentId)
-      ) {
+      if (!canAccessCapability(req.agentId, cap, undefined, undefined)) {
         throw new Error(
           `Agent ${req.agentId} is not allowed for capability ${cap.name}`,
         );

--- a/src/core/directory.ts
+++ b/src/core/directory.ts
@@ -114,6 +114,16 @@ export const serviceDirectory: ServiceTemplate[] = [
     docs: 'https://replicate.com/docs/reference/http',
     tags: ['ai', 'ml', 'models']
   },
+
+  // Web Scraping / Data Extraction
+  {
+    name: 'firecrawl',
+    description: 'Web scraping and crawling API for AI',
+    baseUrl: 'https://api.firecrawl.dev',
+    auth: { type: 'bearer', fields: ['key'] },
+    docs: 'https://docs.firecrawl.dev/api-reference/v2-introduction',
+    tags: ['scraping', 'web', 'ai', 'data']
+  },
   
   // Crypto Exchanges
   {

--- a/src/core/mcp-server.ts
+++ b/src/core/mcp-server.ts
@@ -25,6 +25,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import {
+  canAccessCapability,
   canAgentAccess,
   CredentialOwnership,
   resolveAgentIdentity,
@@ -53,33 +54,6 @@ const packageJsonPath = join(__dirname, "../../package.json");
 const pkgVersion =
   JSON.parse(readFileSync(packageJsonPath, "utf8")).version || "0.0.0";
 
-
-/**
- * Check whether an agent can access a capability.
- * Checks capability-level allowedAgents first, then falls back to
- * service-level ownership and the global defaultAccess policy.
- *
- * No agentId (e.g. CLI/admin) always gets access.
- */
-function canAccessCapability(
-  agentId: string | undefined,
-  cap: Capability,
-  service: ServiceConfig | undefined,
-  defaultAccessPolicy: "open" | "restricted" | undefined,
-): boolean {
-  if (!agentId) return true;
-
-  if (cap.allowedAgents && cap.allowedAgents.length > 0) {
-    return cap.allowedAgents.includes(agentId);
-  }
-
-  const effectiveAccess = cap.access ?? defaultAccessPolicy;
-  if (effectiveAccess === "restricted") {
-    return false;
-  }
-
-  return canAgentAccess(agentId, service?.ownership);
-}
 
 export type AccessDenialReason = 'AGENT_NOT_ALLOWED' | 'DEFAULT_ACCESS_RESTRICTED' | 'OWNERSHIP_DENIED';
 
@@ -561,7 +535,6 @@ export function createMCPServer(options: MCPServerOptions): MCPServerResult {
         resolveAgent: resolveAgentFromRequest,
         clientSessions,
         explainAccessDenial,
-        canAccessCapability,
       };
 
       switch (name) {

--- a/src/core/tool-handlers.ts
+++ b/src/core/tool-handlers.ts
@@ -1,4 +1,5 @@
 import {
+  canAccessCapability,
   canAgentAccess,
   CredentialOwnership,
 } from './agent-scope.js';
@@ -21,7 +22,10 @@ import type {
   APIRequest,
   APIResponse,
 } from './types.js';
-import { DenialError } from './types.js';
+import {
+  DenialError,
+  parseTTL,
+} from './types.js';
 
 export interface ToolHandlerContext {
   getCapabilities: () => Capability[];
@@ -36,21 +40,12 @@ export interface ToolHandlerContext {
   resolveAgent: (extra: any, args: any) => string | undefined;
   clientSessions: Map<string, string>;
   explainAccessDenial: (agentId: string | undefined, cap: Capability, service: ServiceConfig | undefined, defaultAccess: 'open' | 'restricted' | undefined) => { reason: string; detail: string } | null;
-  canAccessCapability: (agentId: string | undefined, cap: Capability, service: ServiceConfig | undefined, defaultAccess: 'open' | 'restricted' | undefined) => boolean;
 }
 
 type ToolResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
 
 function textResult(data: unknown): ToolResult {
   return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
-}
-
-function parseTTL(ttl: string): number {
-  const match = ttl.match(/^(\d+)(s|m|h|d)$/);
-  if (!match) throw new Error(`Invalid TTL format: ${ttl}`);
-  const [, num, unit] = match;
-  const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
-  return parseInt(num) * multipliers[unit];
 }
 
 // ---------------------------------------------------------------------------
@@ -104,7 +99,7 @@ export async function handleExecute(
 
   const executeAgentId = ctx.resolveAgent(extra, args);
   const executeSvc = services.get(cap.service);
-  if (!ctx.canAccessCapability(executeAgentId, cap, executeSvc, ctx.defaultAccess)) {
+  if (!canAccessCapability(executeAgentId, cap, executeSvc, ctx.defaultAccess)) {
     const denialDetail = ctx.explainAccessDenial(executeAgentId, cap, executeSvc, ctx.defaultAccess);
     ctx.auditLogger.logDenied(cap.service, method, path, 'Agent does not have access to this capability', reason);
     throw new DenialError(
@@ -189,7 +184,7 @@ export async function handleExec(
 
     const execAgentId = ctx.resolveAgent(extra, args);
     const execSvc = services.get(execCap.service);
-    if (!ctx.canAccessCapability(execAgentId, execCap, execSvc, ctx.defaultAccess)) {
+    if (!canAccessCapability(execAgentId, execCap, execSvc, ctx.defaultAccess)) {
       const execDenialDetail = ctx.explainAccessDenial(execAgentId, execCap, execSvc, ctx.defaultAccess);
       ctx.auditLogger.logDenied(execCap.service, 'EXEC', execCommand.join(' '), 'Agent does not have access to this capability', execReason);
       throw new DenialError(
@@ -426,11 +421,11 @@ export function handleWhoami(
   const services = ctx.getServices();
 
   const accessibleCaps = capabilities
-    .filter(cap => ctx.canAccessCapability(whoamiAgentId, cap, services.get(cap.service), ctx.defaultAccess))
+    .filter(cap => canAccessCapability(whoamiAgentId, cap, services.get(cap.service), ctx.defaultAccess))
     .map(cap => cap.name);
 
   const deniedCaps = capabilities
-    .filter(cap => !ctx.canAccessCapability(whoamiAgentId, cap, services.get(cap.service), ctx.defaultAccess))
+    .filter(cap => !canAccessCapability(whoamiAgentId, cap, services.get(cap.service), ctx.defaultAccess))
     .map(cap => cap.name);
 
   return textResult({

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,6 +2,24 @@ export const DEFAULT_TIMEOUT_MS = 30_000;
 export const REDACTED = '[REDACTED]';
 export const MIN_SCRUB_LENGTH = 8;
 
+const TTL_PATTERN = /^(\d+)(s|m|h|d)$/;
+const TTL_MULTIPLIERS: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+
+/** Validate a TTL string format (e.g. "30s", "5m", "1h", "7d"). Throws on invalid input. */
+export function validateTTL(ttl: string): void {
+  if (!TTL_PATTERN.test(ttl)) {
+    throw new Error(`Invalid TTL "${ttl}" — expected format like 30s, 5m, 1h, 7d`);
+  }
+}
+
+/** Parse a TTL string into seconds. Throws on invalid input. */
+export function parseTTL(ttl: string): number {
+  const match = ttl.match(TTL_PATTERN);
+  if (!match) throw new Error(`Invalid TTL format: ${ttl}`);
+  const [, num, unit] = match;
+  return parseInt(num) * TTL_MULTIPLIERS[unit];
+}
+
 export interface APIRequest {
   service: string;
   path: string;


### PR DESCRIPTION
## Summary

- Fix 12+ CLI UX gotchas where commands silently succeed with conflicting options, report incorrect access, or create broken configurations
- Consolidate duplicated access evaluation logic (5 implementations → 1 shared `canAccessCapability`/`resolveAccess` in `agent-scope.ts`) and TTL logic (2 → 1 shared `validateTTL`/`parseTTL` in `types.ts`)
- Add color distinction in `janee overview` (cyan = agent-specific, green = globally open)

### Gotcha fixes

| Fix | Severity |
|-----|----------|
| `whoami` and `doctor-bundle` now respect per-capability `access` field | Critical |
| Error on contradictory flags (`--allowed-agents` + `--clear-agents`, `--access` + `--clear-access`, `--clear-rules` + `--allow`/`--deny`) | High |
| `cap add --mode exec` without `--allow-commands` now errors | High |
| `janee add --timeout abc` validates NaN/negative values | High |
| `--access` help text fixed (removed nonexistent "inherit" option) | Medium |
| `cap edit` with no options now errors instead of silent success | Medium |
| TTL format validated at save time | Medium |
| Warn when exec-mode options used on proxy caps (and vice versa) | Medium |
| `--access` warning only fires for pre-existing `allowedAgents` | Medium |
| `revoke` prefix match errors on ambiguous matches | Low |
| `logs` JSON error format normalized to `{ ok: false, error }` | Low |

### Consolidation

- `canAccessCapability()` + `resolveAccess()` → `src/core/agent-scope.ts` (single source of truth, removed from `mcp-server.ts`, `whoami.ts`, `doctor-bundle.ts`, `overview.ts`, `tool-handlers.ts`, `authority.ts`)
- `validateTTL()` + `parseTTL()` → `src/core/types.ts` (removed from `capability.ts`, `tool-handlers.ts`)

## Test plan

- [x] All 541 existing tests pass
- [x] `janee overview` renders correctly with color distinction
- [x] Build clean (no TS errors)
- [ ] Verify conflicting option combos produce clear error messages
- [ ] Verify `cap add --mode exec` without `--allow-commands` errors
- [ ] Verify `cap edit` with no flags errors


Made with [Cursor](https://cursor.com)